### PR TITLE
Theming: Add Basic Color Palette for Light & Dark Theme

### DIFF
--- a/core/design-system/src/main/kotlin/com/elmepa/designsystem/theme/Theme.kt
+++ b/core/design-system/src/main/kotlin/com/elmepa/designsystem/theme/Theme.kt
@@ -1,51 +1,46 @@
 package com.elmepa.designsystem.theme
 
-import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.dynamicDarkColorScheme
-import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.graphics.Color
 
 private val DarkColorScheme = darkColorScheme(
-    primary = Purple80,
+    primary = White,
     secondary = PurpleGrey80,
-    tertiary = Pink80
+    tertiary = Pink80,
+    background = DarkModeSurface, //App background color,
+    onBackground = Color.White, //Text/icons on background
+    surface = DarkModeElement2, //UI surfaces like cards, sheets, dialogs
+    onSurface = Color.White, //Text/icons on surfaces
+    error = Color.Red, //Error messages, warning indicators
+    onError = Color.White, //wText/icons on error color
 )
 
 private val LightColorScheme = lightColorScheme(
-    primary = Purple40,
+    primary = Black,
     secondary = PurpleGrey40,
     tertiary = Pink40,
-    background = LessonOrange,
-    surface = LessonOrange,
-
-    /* Other default colors to override
-    background = Color(0xFFFFFBFE),
-    surface = Color(0xFFFFFBFE),
-    onPrimary = Color.White,
-    onSecondary = Color.White,
-    onTertiary = Color.White,
-    onBackground = Color(0xFF1C1B1F),
-    onSurface = Color(0xFF1C1B1F),
-    */
+    background = GreyBg, //App background color,
+    onBackground = Color.Black, //Text/icons on background
+    surface = Color.White, //UI surfaces like cards, sheets, dialogs
+    onSurface = Color.Black, //Text/icons on surfaces
+    error = Color.Red, //Error messages, warning indicators
+    onError = Color.White, //wText/icons on error color
 )
 
 @Composable
 fun ElmepaAppTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
-    // Dynamic color is available on Android 12+
-    dynamicColor: Boolean = true,
     content: @Composable () -> Unit
 ) {
     val colorScheme = when {
-        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-            val context = LocalContext.current
-            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
-        }
+//        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+//            val context = LocalContext.current
+//            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+//        }
 
         darkTheme -> DarkColorScheme
         else -> LightColorScheme


### PR DESCRIPTION
### Description

This PR adds a basic color palette in the codebase in order to help with the `Compose` migration.

### Implementation

- Added the following colors:


#### 🌙 Dark Mode Color Scheme  

| **Role**        | **Color**                  | **Usage**                                      |
|---------------|--------------------------|----------------------------------------------|
| `primary`     | `#FFFFFF` (White)         | Main brand color, buttons, FABs, icons       |
| `secondary`   | `#625B71` (PurpleGrey80)  | Secondary elements, less emphasis            |
| `tertiary`    | `#7D5260` (Pink80)        | Accent color for interactive elements        |
| `background`  | `#121212` (DarkModeSurface) | App background color                         |
| `onBackground` | `#FFFFFF` (White)         | Text/icons on background                     |
| `surface`     | `#222222` (DarkModeElement2) | UI surfaces like cards, sheets, dialogs     |
| `onSurface`   | `#FFFFFF` (White)         | Text/icons on surfaces                       |
| `error`       | `#FF0000` (Red)           | Error messages, warning indicators          |
| `onError`     | `#FFFFFF` (White)         | Text/icons on error color                    |

---

#### ☀️ Light Mode Color Scheme  

| **Role**        | **Color**                  | **Usage**                                      |
|---------------|--------------------------|----------------------------------------------|
| `primary`     | `#000000` (Black)         | Main brand color, buttons, FABs, icons       |
| `secondary`   | `#CCC2DC` (PurpleGrey40)  | Secondary elements, less emphasis            |
| `tertiary`    | `#EFB8C8` (Pink40)        | Accent color for interactive elements        |
| `background`  | `#F0F0F0` (GreyBg)        | App background color                         |
| `onBackground` | `#000000` (Black)         | Text/icons on background                     |
| `surface`     | `#FFFFFF` (White)         | UI surfaces like cards, sheets, dialogs     |
| `onSurface`   | `#000000` (Black)         | Text/icons on surfaces                       |
| `error`       | `#FF0000` (Red)           | Error messages, warning indicators          |
| `onError`     | `#FFFFFF` (White)         | Text/icons on error color                    |

---