### PR TITLE
Add Loading composable on FAQ screen

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/elmepa/convention/ext/AndroidCompose.kt
+++ b/build-logic/convention/src/main/kotlin/com/elmepa/convention/ext/AndroidCompose.kt
@@ -21,6 +21,7 @@ internal fun Project.configureAndroidCompose(
         dependencies {
             val bom = libs.findLibrary("androidx-compose-bom").get()
             add("implementation", platform(bom))
+            add("implementation", libs.findLibrary("androidx-ui-graphics").get())
             add("implementation", libs.findLibrary("androidx-compose-ui-tooling-preview").get())
             add("implementation", libs.findLibrary("androidx-compose-material3").get())
             add("implementation", libs.findLibrary("androidx-lifecycle-runtime-compose").get())

--- a/core/design-system/src/main/kotlin/com/elmepa/designsystem/components/shimmer/ShimmerEffect.kt
+++ b/core/design-system/src/main/kotlin/com/elmepa/designsystem/components/shimmer/ShimmerEffect.kt
@@ -1,0 +1,80 @@
+package com.elmepa.designsystem.components.shimmer
+
+import androidx.compose.animation.core.FastOutLinearInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import com.elmepa.designsystem.theme.GreyLight
+import com.elmepa.designsystem.theme.ShimmerGreyLighter
+
+@Composable
+fun ShimmerEffect(
+    modifier: Modifier,
+    widthOfShadowBrush: Int = 500,
+    angleOfAxisY: Float = 270f,
+    durationMillis: Int = 1000,
+) {
+
+    val shimmerColors = listOf(
+        GreyLight.copy(alpha = 0.3f),
+        GreyLight.copy(alpha = 0.5f),
+        GreyLight.copy(alpha = 1.0f),
+        GreyLight.copy(alpha = 0.5f),
+        GreyLight.copy(alpha = 0.3f),
+    )
+
+    val transition = rememberInfiniteTransition(label = "")
+
+    val translateAnimation = transition.animateFloat(
+        initialValue = 0f,
+        targetValue = (durationMillis + widthOfShadowBrush).toFloat(),
+        animationSpec = infiniteRepeatable(
+            animation = tween(
+                durationMillis = durationMillis,
+                easing = FastOutLinearInEasing,
+            ),
+            repeatMode = RepeatMode.Restart,
+        ),
+        label = "Shimmer loading animation",
+    )
+
+    val brush = Brush.linearGradient(
+        colors = shimmerColors,
+        start = Offset(x = translateAnimation.value - widthOfShadowBrush, y = 0.0f),
+        end = Offset(x = translateAnimation.value, y = angleOfAxisY),
+    )
+
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(16))
+            .background(ShimmerGreyLighter)
+    ) {
+        Card(
+            modifier = modifier
+                .fillMaxWidth(),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.background)
+        ) {
+            Spacer(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(brush)
+            )
+        }
+    }
+}

--- a/feature/supportv2/support-ui/src/main/kotlin/com/elmepa/supportv2/ui/faq/FaqScreen.kt
+++ b/feature/supportv2/support-ui/src/main/kotlin/com/elmepa/supportv2/ui/faq/FaqScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.core.text.HtmlCompat
 import com.elmepa.designsystem.components.cards.ExpandableCard
+import com.elmepa.supportv2.ui.faq.components.FaqShimmerLoading
 import com.stathis.model.support.Faq
 
 @Composable
@@ -25,7 +26,12 @@ fun FaqScreen(state: FaqView.State) {
         },
         content = { paddingValues ->
             when (state) {
-                is FaqView.State.Loading -> Unit
+                is FaqView.State.Loading -> FaqShimmerLoading(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .consumeWindowInsets(paddingValues)
+                )
+
                 is FaqView.State.Content -> FaqContent(
                     paddingValues = paddingValues,
                     faqs = state.faqs

--- a/feature/supportv2/support-ui/src/main/kotlin/com/elmepa/supportv2/ui/faq/FaqViewModel.kt
+++ b/feature/supportv2/support-ui/src/main/kotlin/com/elmepa/supportv2/ui/faq/FaqViewModel.kt
@@ -31,9 +31,7 @@ internal class FaqViewModel @Inject constructor(
 
     private fun getFaqs() {
         fetchFaqUseCase()
-            .onEach { result ->
-                _state.update { result.toUiState() }
-            }
+            .onEach { result -> _state.update { result.toUiState() } }
             .flowOn(Dispatchers.IO)
             .launchIn(viewModelScope)
     }

--- a/feature/supportv2/support-ui/src/main/kotlin/com/elmepa/supportv2/ui/faq/components/FaqShimmerLoading.kt
+++ b/feature/supportv2/support-ui/src/main/kotlin/com/elmepa/supportv2/ui/faq/components/FaqShimmerLoading.kt
@@ -1,0 +1,44 @@
+package com.elmepa.supportv2.ui.faq.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.elmepa.designsystem.components.shimmer.ShimmerEffect
+import com.elmepa.designsystem.theme.ElmepaAppTheme
+
+@Composable
+internal fun FaqShimmerLoading(modifier: Modifier = Modifier) {
+    LazyColumn(
+        modifier = modifier
+            .padding(top = 8.dp)
+            .padding(horizontal = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        items(count = 10) {
+            ShimmerEffect(
+                modifier = Modifier
+                    .height(70.dp)
+                    .fillMaxWidth()
+            )
+        }
+
+        item {
+            Spacer(modifier = Modifier.height(40.dp))
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun FaqShimmerLoadingPreview() {
+    ElmepaAppTheme {
+        FaqShimmerLoading(modifier = Modifier.padding(all = 8.dp))
+    }
+}


### PR DESCRIPTION
### Description

This PR adds the loading composable to the FAQ screen for initial loading.

### Implementation

- Create `Shimmer` effect composable to be reusable across project
- Use new `Shimmer` composable to create the loading composable inside FAQ screen