### PR TITLE
Add informative card to design system

### DIFF
--- a/core/design-system/src/main/kotlin/com/elmepa/designsystem/components/cards/InformativeCard.kt
+++ b/core/design-system/src/main/kotlin/com/elmepa/designsystem/components/cards/InformativeCard.kt
@@ -1,0 +1,57 @@
+package com.elmepa.designsystem.components.cards
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
+import androidx.compose.ui.unit.dp
+import com.elmepa.designsystem.theme.ElmepaAppTheme
+import com.elmepa.designsystem.theme.LightBlue
+import com.elmepa.designsystem.theme.Navy
+
+@Composable
+fun InformativeCard(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    Card(
+        modifier = modifier.clickable(enabled = false, onClick = {}),
+    ) {
+        Row(
+            Modifier
+                .fillMaxWidth()
+                .background(LightBlue)
+                .padding(all = 16.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Default.Info,
+                contentDescription = null,
+                tint = Navy
+            )
+            Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+                content()
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun InformativeCardPreview() {
+    ElmepaAppTheme {
+        InformativeCard {
+            Text(LoremIpsum(8).values.joinToString())
+        }
+    }
+}


### PR DESCRIPTION
### 📝  Description

This PR adds the informative card component to the design system. 

---

### 🔄  Implementation

- Created `InformativeCard` composable & preview
---

### 🎬  Demo

<img width="341" alt="Screenshot 2025-03-15 at 6 50 30 PM" src="https://github.com/user-attachments/assets/ee72c18d-b963-40b3-97c7-d7288defd64e" />

---

### 🧪  Testing

- N/A