### PR TITLE
Migrate about app screen to compose

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -103,6 +103,7 @@ dependencies {
 
     implementation(libs.fragment.navigation)
     implementation(libs.ui.navigation)
+    implementation(libs.navigation.fragment.compose)
 
     implementation(libs.firebase.crashlytics)
     implementation(libs.firebase.perf)

--- a/app/src/main/java/com/stathis/elmepaunivapp/MainActivity.kt
+++ b/app/src/main/java/com/stathis/elmepaunivapp/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.stathis.elmepaunivapp
 
 import android.view.MenuItem
+import android.view.View
 import androidx.activity.viewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -36,9 +37,16 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
 
         binding.bottomNavView.setupWithNavController(navController)
 
-        navController.addOnDestinationChangedListener { _, _, _ ->
+        navController.addOnDestinationChangedListener { _, destination, _ ->
             val isAtHomeScreens = navigator.isAtHomeScreens()
             supportActionBar?.setDisplayHomeAsUpEnabled(!isAtHomeScreens)
+
+            val shouldHideToolbar = destination.id == R.id.aboutAppScreen
+            binding.toolbar.visibility = if (shouldHideToolbar) {
+                View.GONE
+            } else {
+                View.VISIBLE
+            }
         }
 
         val cameFromWidget = intent.getBooleanExtra(getString(R.string.open_personnel), false)

--- a/app/src/main/java/com/stathis/elmepaunivapp/navigation/NavigatorImpl.kt
+++ b/app/src/main/java/com/stathis/elmepaunivapp/navigation/NavigatorImpl.kt
@@ -44,7 +44,7 @@ class NavigatorImpl @Inject constructor(
         NavigationAction.WEBVIEW -> navController.navigateSafe(R.id.webViewFragment, bundle)
         NavigationAction.CONTACT -> navController.navigateSafe(R.id.contactFragment)
         NavigationAction.FAQ -> navController.navigateSafe(R.id.faqFragment)
-        NavigationAction.ABOUT_APP -> navController.navigateSafe(R.id.aboutAppFragment)
+        NavigationAction.ABOUT_APP -> navController.navigateSafe(R.id.aboutAppScreen)
         else -> Unit
     }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -11,15 +11,15 @@
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"
-            android:theme="@style/AppToolbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:theme="@style/AppToolbar"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
         <androidx.fragment.app.FragmentContainerView
             android:id="@+id/navHostFragment"
-            android:name="androidx.navigation.fragment.NavHostFragment"
+            android:name="androidx.navigation.fragment.compose.ComposableNavHostFragment"
             android:layout_width="match_parent"
             android:layout_height="0dp"
             app:defaultNavHost="true"

--- a/app/src/main/res/navigation/feature_nav.xml
+++ b/app/src/main/res/navigation/feature_nav.xml
@@ -64,11 +64,9 @@
         android:label="LessonDetailsFragment"
         tools:layout="@layout/fragment_lesson_details" />
 
-    <fragment
-        android:id="@+id/aboutAppFragment"
-        android:name="com.stathis.support.ui.about.AboutAppFragment"
-        android:label="AboutAppFragment"
-        tools:layout="@layout/fragment_about_app" />
+    <composable
+        android:id="@+id/aboutAppScreen"
+        android:name="com.elmepa.supportv2.ui.about.AboutAppScreenKt\$AboutAppScreen" />
 
     <fragment
         android:id="@+id/contactFragment"

--- a/core/common/src/main/res/values/strings.xml
+++ b/core/common/src/main/res/values/strings.xml
@@ -81,7 +81,7 @@
     <string name="faq_title">Συχνές Ερωτήσεις</string>
 
     <!-- About App-->
-    <string name="about_app_data">Η εφαρμογή χρησιμοποιεί δεδομένα το website της σχολής (https://mst.hmu.gr/). Τα δεδομένα αυτά ανήκουν στο ΕΛΜΕΠΑ (Τμήμα ΔΕΤ - Άγιος Νικόλαος).</string>
+    <string name="about_app_data">Η εφαρμογή χρησιμοποιεί δεδομένα από το website της σχολής (https://mst.hmu.gr/). Τα δεδομένα αυτά ανήκουν στο ΕΛΜΕΠΑ (Τμήμα ΔΕΤ - Άγιος Νικόλαος).</string>
     <string name="news_publisher_header">News Publisher</string>
     <string name="news_publisher_desc">E–mail: secretariat-mst@hmu.gr\nΤηλ.: 28410–91103</string>
 

--- a/core/design-system/src/main/kotlin/com/elmepa/designsystem/components/cards/InformativeCard.kt
+++ b/core/design-system/src/main/kotlin/com/elmepa/designsystem/components/cards/InformativeCard.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.Card
@@ -35,11 +36,12 @@ fun InformativeCard(
                 .padding(all = 16.dp)
         ) {
             Icon(
+                modifier = Modifier.size(24.dp),
                 imageVector = Icons.Default.Info,
                 contentDescription = null,
                 tint = Navy
             )
-            Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+            Column(modifier = Modifier.padding(start = 16.dp)) {
                 content()
             }
         }

--- a/core/design-system/src/main/kotlin/com/elmepa/designsystem/components/cards/TimelineCard.kt
+++ b/core/design-system/src/main/kotlin/com/elmepa/designsystem/components/cards/TimelineCard.kt
@@ -1,0 +1,116 @@
+package com.elmepa.designsystem.components.cards
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.VerticalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun TimelineCard(
+    modifier: Modifier = Modifier,
+    title: String,
+    description: String,
+) {
+    var cardHeight: Dp by remember { mutableStateOf(0.dp) }
+    val localDensity = LocalDensity.current
+
+    Row(modifier = modifier) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            VerticalDivider(
+                modifier = Modifier.height(16.dp),
+                thickness = 3.dp,
+                color = Color.LightGray
+            )
+            Canvas(modifier = Modifier.size(16.dp)) {
+                drawCircle(color = Color.LightGray)
+            }
+
+            VerticalDivider(
+                modifier = Modifier.height(cardHeight + 16.dp),
+                thickness = 3.dp,
+                color = Color.LightGray
+            )
+        }
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        Column {
+            MainContent(
+                title = title,
+                description = description,
+                onGloballyPositioned = { intSize ->
+                    with(localDensity) {
+                        cardHeight = intSize.height.toDp()
+                    }
+                }
+            )
+            Spacer(Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun MainContent(title: String, description: String, onGloballyPositioned: (IntSize) -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(16.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(all = 16.dp)
+            .onGloballyPositioned { coordinates ->
+                onGloballyPositioned(coordinates.size)
+            }
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = description,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    }
+}
+
+@Preview
+@Composable
+fun TimelineScreenPreview() {
+    Column(modifier = Modifier.fillMaxSize()) {
+        TimelineCard(
+            title = LoremIpsum(3).values.joinToString(),
+            description = LoremIpsum(15).values.joinToString()
+        )
+    }
+}

--- a/feature/supportv2/support-ui/src/main/kotlin/com/elmepa/supportv2/ui/about/AboutAppScreen.kt
+++ b/feature/supportv2/support-ui/src/main/kotlin/com/elmepa/supportv2/ui/about/AboutAppScreen.kt
@@ -1,0 +1,160 @@
+package com.elmepa.supportv2.ui.about
+
+import android.annotation.SuppressLint
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarColors
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.findNavController
+import com.elmepa.designsystem.components.cards.InformativeCard
+import com.elmepa.designsystem.components.cards.TimelineCard
+import com.elmepa.designsystem.theme.ElmepaAppTheme
+import com.elmepa.designsystem.theme.Petrol
+import com.stathis.common.R
+import com.stathis.model.about.AboutAppCard
+
+@OptIn(ExperimentalMaterial3Api::class)
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+@Composable
+fun AboutAppScreen() {
+    val navController = LocalView.current.findNavController()
+
+    ElmepaAppTheme {
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = {
+                        Text(
+                            text = stringResource(R.string.about_app_title),
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                    },
+                    colors = TopAppBarColors(
+                        containerColor = Petrol,
+                        scrolledContainerColor = Color.Red,
+                        navigationIconContentColor = Color.White,
+                        titleContentColor = Color.White,
+                        actionIconContentColor = Color.White
+                    ),
+                    navigationIcon = {
+                        IconButton(
+                            onClick = { navController.popBackStack() }
+                        ) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Default.KeyboardArrowLeft,
+                                contentDescription = null
+                            )
+                        }
+                    }
+                )
+            },
+            content = { paddingValues ->
+                AboutAppContent(
+                    paddingValues = paddingValues,
+                    info = getAboutAppInfo()
+                )
+            }
+        )
+    }
+}
+
+@Composable
+internal fun AboutAppContent(paddingValues: PaddingValues, info: List<AboutAppCard>) {
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp)
+            .background(MaterialTheme.colorScheme.background),
+        contentPadding = paddingValues
+    ) {
+        item {
+            InformativeCard(modifier = Modifier.padding(vertical = 16.dp)) {
+                InformativeCardContent(
+                    infoText = stringResource(R.string.about_app_data),
+                    newsPublisher = stringResource(R.string.news_publisher_header),
+                    contactInfo = stringResource(R.string.news_publisher_desc)
+                )
+            }
+        }
+
+        items(info, key = { it.date }) { data ->
+            TimelineCard(
+                title = data.date,
+                description = data.description
+            )
+        }
+    }
+}
+
+@Composable
+private fun InformativeCardContent(infoText: String, newsPublisher: String, contactInfo: String) {
+    Text(
+        text = infoText,
+        style = MaterialTheme.typography.bodyMedium,
+        textAlign = TextAlign.Justify,
+        color = MaterialTheme.colorScheme.onSurface
+    )
+    Spacer(Modifier.height(16.dp))
+    Text(
+        text = newsPublisher,
+        color = MaterialTheme.colorScheme.onSurface,
+        fontWeight = FontWeight.Bold
+    )
+    Spacer(Modifier.height(4.dp))
+    Text(
+        text = contactInfo,
+        color = MaterialTheme.colorScheme.onSurface,
+        style = MaterialTheme.typography.bodyMedium,
+    )
+}
+
+@Preview
+@Composable
+private fun AboutAppScreenPreview() {
+    ElmepaAppTheme {
+        AboutAppScreen()
+    }
+}
+
+@Composable
+private fun getAboutAppInfo() = listOf(
+    AboutAppCard(
+        date = stringResource(R.string.new_version_date),
+        description = stringResource(R.string.new_version_desc),
+    ),
+    AboutAppCard(
+        date = stringResource(R.string.third_version_date),
+        description = stringResource(R.string.third_version_desc)
+    ),
+    AboutAppCard(
+        date = stringResource(R.string.sec_version_date),
+        description = stringResource(R.string.sec_version_desc)
+    ),
+    AboutAppCard(
+        date = stringResource(R.string.first_version_date),
+        description = stringResource(R.string.first_version_desc)
+    )
+)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -74,6 +74,7 @@ androidx-activity = { group = "androidx.activity", name = "activity", version.re
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 fragment-navigation = { group = "androidx.navigation", name = "navigation-fragment-ktx", version.ref = "navigation" }
 ui-navigation = { group = "androidx.navigation", name = "navigation-ui-ktx", version.ref = "navigation" }
+navigation-fragment-compose = { group = "androidx.navigation", name = "navigation-fragment-compose", version.ref = "navigation" }
 
 #Delete after compose migration
 viewModelLifecycle = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycle" }


### PR DESCRIPTION
### 📝  Description

This PR migrates the `About app` screen to `Jetpack Compose`


---

### 🔄  Implementation

- Added `AboutAppScreen`
- Replaced `AboutAppFragment` with `AboutAppScreen` in nav graph.

---

### 🎬  Demo

N/A

---

### 🧪  Testing

From `Home`, click on `Σχετικά με την εφαρμογή`
