### PR TITLE
Add personnelv2 module tree

### DIFF
--- a/feature/personnelv2/personnel-data/build.gradle.kts
+++ b/feature/personnelv2/personnel-data/build.gradle.kts
@@ -1,0 +1,25 @@
+plugins {
+    alias(libs.plugins.elmepa.android.library)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.elmepa.android.hilt)
+    alias(libs.plugins.elmepa.android.room)
+}
+
+android {
+    namespace = "com.elmepa.personnel.data"
+}
+
+dependencies {
+    implementation(project(":core:data"))
+    implementation(project(":core:common"))
+    implementation(project(":core:model"))
+    implementation(project(":core:domain"))
+    implementation(project(":core:datastore"))
+
+    implementation(project(":feature:personnelv2:personnel-database"))
+    implementation(project(":feature:personnelv2:personnel-domain"))
+
+    implementation(libs.firebase.firestore)
+
+    implementation(libs.jsoup)
+}

--- a/feature/personnelv2/personnel-data/src/main/kotlin/com/elmepa/personnel/di/PersonnelRepositoryModule.kt
+++ b/feature/personnelv2/personnel-data/src/main/kotlin/com/elmepa/personnel/di/PersonnelRepositoryModule.kt
@@ -1,0 +1,18 @@
+package com.elmepa.personnel.di
+
+import com.elmepa.personnel.remote.repository.PersonnelRepositoryImpl
+import com.elmepa.personnel.repository.PersonnelRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal abstract class PersonnelRepositoryModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindSupportRepository(impl: PersonnelRepositoryImpl): PersonnelRepository
+}

--- a/feature/personnelv2/personnel-data/src/main/kotlin/com/elmepa/personnel/remote/mapper/PersonnelMapper.kt
+++ b/feature/personnelv2/personnel-data/src/main/kotlin/com/elmepa/personnel/remote/mapper/PersonnelMapper.kt
@@ -1,0 +1,23 @@
+package com.elmepa.personnel.remote.mapper
+
+import com.elmepa.personnel.remote.model.PersonnelDto
+import com.stathis.common.util.toNotNull
+import com.stathis.data.remote.mapper.BaseMapper
+import com.stathis.model.personnel.Person
+
+internal object PersonnelMapper : BaseMapper<List<PersonnelDto>?, List<Person>> {
+
+    override fun toDomainModel(dtoModel: List<PersonnelDto>?) = dtoModel?.map {
+        it.toDomainModel()
+    } ?: listOf()
+
+    private fun PersonnelDto?.toDomainModel() = Person(
+        fullName = this?.fullName.toNotNull(),
+        description = this?.description.toNotNull(),
+        image = this?.image.toNotNull(),
+        email = this?.email.toNotNull(),
+        gender = this?.gender.toNotNull(),
+        vocative = this?.vocative.toNotNull()
+    )
+}
+

--- a/feature/personnelv2/personnel-data/src/main/kotlin/com/elmepa/personnel/remote/model/PersonnelDto.kt
+++ b/feature/personnelv2/personnel-data/src/main/kotlin/com/elmepa/personnel/remote/model/PersonnelDto.kt
@@ -1,0 +1,10 @@
+package com.elmepa.personnel.remote.model
+
+internal data class PersonnelDto(
+    val fullName: String? = null,
+    val description: String? = null,
+    val image: String? = null,
+    val email: String? = null,
+    val gender: String? = null,
+    val vocative: String? = null
+)

--- a/feature/personnelv2/personnel-data/src/main/kotlin/com/elmepa/personnel/remote/repository/PersonnelRepositoryImpl.kt
+++ b/feature/personnelv2/personnel-data/src/main/kotlin/com/elmepa/personnel/remote/repository/PersonnelRepositoryImpl.kt
@@ -1,0 +1,33 @@
+package com.elmepa.personnel.remote.repository
+
+import com.google.firebase.firestore.FirebaseFirestore
+import com.stathis.data.remote.mapper.personnel.PersonnelMapper
+import com.stathis.data.remote.model.personnel.PersonnelDto
+import com.stathis.data.util.FULLNAME
+import com.stathis.data.util.PERSONNEL_DB_PATH
+import com.stathis.domain.model.DomainResult
+import com.stathis.model.UiModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+
+internal class PersonnelRepositoryImpl @Inject constructor(
+    private val fireStore: FirebaseFirestore
+) : com.elmepa.personnel.repository.PersonnelRepository {
+
+    override fun fetchAllPersonnel(): Flow<DomainResult<List<UiModel>>> = flow {
+        val result = fireStore.collection(PERSONNEL_DB_PATH)
+            .orderBy(FULLNAME)
+            .get()
+            .await()
+            .toObjects(PersonnelDto::class.java)
+
+        val personnel = PersonnelMapper.toDomainModel(result)
+        emit(DomainResult.Success(personnel))
+    }
+
+    override fun searchPersonnelByName(name: String): Flow<DomainResult<List<UiModel>>> = flow {
+        emit(DomainResult.Success(listOf()))
+    }
+}

--- a/feature/personnelv2/personnel-database/build.gradle.kts
+++ b/feature/personnelv2/personnel-database/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    alias(libs.plugins.elmepa.android.library)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.elmepa.android.hilt)
+    alias(libs.plugins.elmepa.android.room)
+}
+
+android {
+    namespace = "com.elmepa.personnel.database"
+}
+
+dependencies {
+    implementation(project(":core:model"))
+    implementation(project(":feature:personnelv2:personnel-domain"))
+}

--- a/feature/personnelv2/personnel-database/src/main/kotlin/com/elmepa/personnel/db/PersonEntity.kt
+++ b/feature/personnelv2/personnel-database/src/main/kotlin/com/elmepa/personnel/db/PersonEntity.kt
@@ -1,0 +1,21 @@
+package com.elmepa.personnel.db
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import java.util.UUID
+
+private const val PEOPLE = "people"
+
+@Entity(tableName = PEOPLE)
+data class PersonEntity(
+
+    @PrimaryKey(autoGenerate = false)
+    private val id: UUID = UUID.randomUUID(),
+
+    val fullName: String,
+    val description: String,
+    val image: String,
+    val email: String,
+    val gender: String,
+    val vocative: String
+)

--- a/feature/personnelv2/personnel-database/src/main/kotlin/com/elmepa/personnel/db/PersonnelDao.kt
+++ b/feature/personnelv2/personnel-database/src/main/kotlin/com/elmepa/personnel/db/PersonnelDao.kt
@@ -1,0 +1,22 @@
+package com.elmepa.personnel.db
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface PersonnelDao {
+
+    @Query("SELECT * FROM people")
+    fun getAllPersonnel(): Flow<List<PersonEntity>>
+
+    @Query("SELECT * FROM Personnel WHERE fullName LIKE :fullName||'%'")
+    fun getPersonnelByFullName(fullName: String): Flow<List<PersonEntity>>
+
+    @Insert
+    suspend fun insertAll(items: List<PersonEntity>)
+
+    @Query("DELETE FROM people")
+    suspend fun deleteAll()
+}

--- a/feature/personnelv2/personnel-database/src/main/kotlin/com/elmepa/personnel/db/PersonnelLocalDatasource.kt
+++ b/feature/personnelv2/personnel-database/src/main/kotlin/com/elmepa/personnel/db/PersonnelLocalDatasource.kt
@@ -1,0 +1,14 @@
+package com.elmepa.personnel.db
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+
+@Database(
+    entities = [PersonEntity::class],
+    version = 1,
+    exportSchema = false
+)
+abstract class PersonnelLocalDatasource : RoomDatabase() {
+
+    abstract fun personnelDao(): PersonnelDao
+}

--- a/feature/personnelv2/personnel-database/src/main/kotlin/com/elmepa/personnel/di/PersonnelDatabaseModule.kt
+++ b/feature/personnelv2/personnel-database/src/main/kotlin/com/elmepa/personnel/di/PersonnelDatabaseModule.kt
@@ -1,0 +1,25 @@
+package com.elmepa.personnel.di
+
+import android.app.Application
+import androidx.room.Room
+import com.elmepa.personnel.db.PersonnelLocalDatasource
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+const val PERSONNEL_DB_NAME = "personnel_db"
+
+@Module
+@InstallIn(SingletonComponent::class)
+class PersonnelDatabaseModule {
+
+    @Provides
+    @Singleton
+    fun providePersonnelDatabase(application: Application) = Room.databaseBuilder(
+        application.applicationContext,
+        PersonnelLocalDatasource::class.java,
+        PERSONNEL_DB_NAME
+    ).fallbackToDestructiveMigration().build()
+}

--- a/feature/personnelv2/personnel-database/src/main/kotlin/com/elmepa/personnel/mapper/PersonMapper.kt
+++ b/feature/personnelv2/personnel-database/src/main/kotlin/com/elmepa/personnel/mapper/PersonMapper.kt
@@ -1,0 +1,22 @@
+package com.elmepa.personnel.mapper
+
+import com.elmepa.personnel.db.PersonEntity
+import com.stathis.model.personnel.Person
+
+fun Person.toEntity() = PersonEntity(
+    fullName = fullName,
+    description = description,
+    image = image,
+    email = email,
+    gender = gender,
+    vocative = vocative
+)
+
+fun PersonEntity.toPerson() = Person(
+    fullName = fullName,
+    description = description,
+    image = image,
+    email = email,
+    gender = gender,
+    vocative = vocative
+)

--- a/feature/personnelv2/personnel-domain/build.gradle.kts
+++ b/feature/personnelv2/personnel-domain/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    alias(libs.plugins.elmepa.android.library)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.elmepa.android.hilt)
+}
+
+android {
+    namespace = "com.elmepa.personnel.domain"
+}
+
+dependencies {
+    implementation(project(":core:common"))
+    implementation(project(":core:model"))
+    implementation(project(":core:domain"))
+}

--- a/feature/personnelv2/personnel-domain/src/main/kotlin/com/elmepa/personnel/repository/PersonnelRepository.kt
+++ b/feature/personnelv2/personnel-domain/src/main/kotlin/com/elmepa/personnel/repository/PersonnelRepository.kt
@@ -1,0 +1,12 @@
+package com.elmepa.personnel.repository
+
+import com.stathis.domain.model.DomainResult
+import com.stathis.model.UiModel
+import kotlinx.coroutines.flow.Flow
+
+interface PersonnelRepository {
+
+    fun fetchAllPersonnel(): Flow<DomainResult<List<UiModel>>>
+
+    fun searchPersonnelByName(name: String): Flow<DomainResult<List<UiModel>>>
+}

--- a/feature/personnelv2/personnel-domain/src/main/kotlin/com/elmepa/personnel/usecase/FetchPersonnelUseCase.kt
+++ b/feature/personnelv2/personnel-domain/src/main/kotlin/com/elmepa/personnel/usecase/FetchPersonnelUseCase.kt
@@ -1,0 +1,16 @@
+package com.elmepa.personnel.usecase
+
+import com.elmepa.personnel.repository.PersonnelRepository
+import com.stathis.domain.model.DomainResult
+import com.stathis.model.UiModel
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class FetchPersonnelUseCase @Inject constructor(private val repository: PersonnelRepository) {
+
+    operator fun invoke(query: String? = null): Flow<DomainResult<List<UiModel>>> = query?.let { name ->
+        repository.searchPersonnelByName(name)
+    } ?: run {
+        repository.fetchAllPersonnel()
+    }
+}

--- a/feature/personnelv2/personnel-ui/build.gradle.kts
+++ b/feature/personnelv2/personnel-ui/build.gradle.kts
@@ -1,0 +1,29 @@
+plugins {
+    alias(libs.plugins.elmepa.android.feature)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.elmepa.android.hilt)
+    alias(libs.plugins.elmepa.android.library)
+    alias(libs.plugins.elmepa.android.compose)
+    alias(libs.plugins.compose.compiler)
+}
+
+android {
+    namespace = "com.elmepa.personnel.ui"
+}
+
+dependencies {
+    implementation(project(":core:model"))
+    implementation(project(":core:common"))
+    implementation(project(":core:design-system"))
+
+    implementation(project(":core:domain"))
+    implementation(project(":feature:personnelv2:personnel-domain"))
+
+    implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.appcompat)
+
+    implementation(libs.fragment.navigation)
+
+    implementation(libs.viewModelLifecycle)
+    implementation(libs.lifecycle.common)
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -41,6 +41,14 @@ include(":feature:support:support-database")
 include(":feature:support:support-domain")
 include(":feature:support:support-ui")
 
+// Personnel
+include(":feature:personnel")
+include(":feature:personnelv2:personnel-data")
+include(":feature:personnelv2:personnel-database")
+include(":feature:personnelv2:personnel-domain")
+include(":feature:personnelv2:personnel-ui")
+
+
 include(":feature:syllabus")
 include(":feature:personnel")
 include(":feature:news")


### PR DESCRIPTION
### 📝  Description

This PR introduces the `personnelv2` module that will be used to migrate `personnel` to Jetpack Compose

---

### 🔄  Implementation

- Add `personnelv2`

---

### 🎬  Demo

N/A
---

### 🧪  Testing
N/A
