### PR TITLE
Create overview card for dep details screen

### DIFF
--- a/core/design-system/src/main/kotlin/com/elmepa/designsystem/theme/Type.kt
+++ b/core/design-system/src/main/kotlin/com/elmepa/designsystem/theme/Type.kt
@@ -20,14 +20,14 @@ val Typography = Typography(
         fontWeight = FontWeight.Normal,
         fontSize = 16.sp,
         lineHeight = 24.sp,
-        letterSpacing = 0.5.sp
+        letterSpacing = 0.3.sp
     ),
     bodySmall = TextStyle(
         fontFamily = FontFamily.Default,
         fontWeight = FontWeight.Normal,
         fontSize = 14.sp,
         lineHeight = 24.sp,
-        letterSpacing = 0.5.sp
+        letterSpacing = 0.3.sp
     ),
     titleLarge = TextStyle(
         fontSize = 22.sp,

--- a/feature/personnelv2/personnel-ui/src/main/kotlin/com/elmepa/personnel/depdetails/components/PersonalOverviewCard.kt
+++ b/feature/personnelv2/personnel-ui/src/main/kotlin/com/elmepa/personnel/depdetails/components/PersonalOverviewCard.kt
@@ -1,0 +1,91 @@
+package com.elmepa.personnel.depdetails.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import com.elmepa.designsystem.theme.ElmepaAppTheme
+import com.stathis.common.R as common
+
+@Composable
+internal fun PersonalOverviewCard(
+    imageUrl: String,
+    fullName: String,
+    jobTitle: String,
+    description: String
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(all = 16.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Spacer(modifier = Modifier.height(16.dp))
+            AsyncImage(
+                modifier = Modifier
+                    .size(150.dp)
+                    .clip(CircleShape),
+                model = imageUrl,
+                placeholder = painterResource(common.drawable.placeholder),
+                error = painterResource(common.drawable.placeholder),
+                contentDescription = fullName
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = fullName,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                textAlign = TextAlign.Center
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = jobTitle,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodyMedium,
+                textAlign = TextAlign.Justify,
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun PersonalOverviewCardPreview() {
+    ElmepaAppTheme {
+        PersonalOverviewCard(
+            imageUrl = "https://firebasestorage.googleapis.com/v0/b/elmepa-univ-app.appspot.com/o/professors%2Fgvasileiadis.png?alt=media&token=b3518f7c-d952-4284-84f8-75d5f719e14f",
+            fullName = "Test Testopoulos",
+            jobTitle = "Έκτακτο Εκπαιδευτικό Προσωπικό",
+            description = LoremIpsum(15).values.joinToString()
+        )
+    }
+}


### PR DESCRIPTION
### 📝  Description

This PR introduces the `PersonalOverviewCard` composable used in `Dep Details Fragment` in the codebase.

---

### 🔄  Implementation

- Created `PersonalOverviewCard` composable

---

### 🎬  Demo

N/A

---

### 🧪  Testing

- Run the preview on the emulator
