### PR TITLE
Add dep details screen state

### DIFF
--- a/feature/personnelv2/personnel-ui/src/main/kotlin/com/elmepa/personnel/depdetails/DepDetailsView.kt
+++ b/feature/personnelv2/personnel-ui/src/main/kotlin/com/elmepa/personnel/depdetails/DepDetailsView.kt
@@ -1,0 +1,21 @@
+package com.elmepa.personnel.depdetails
+
+import com.stathis.model.common.Link
+import com.stathis.model.department.DepMember
+
+internal sealed class DepDetailsView {
+
+    sealed interface State {
+        data object Loading : State
+        data class Content(val depMember: DepMember)
+    }
+
+    sealed interface UIAction {
+        data class OpenLink(val link: Link) : UIAction
+    }
+
+    sealed interface Effect {
+        data class OpenBrowser(val url: String) : Effect
+        data class SendEmail(val email: String) : Effect
+    }
+}


### PR DESCRIPTION
### 📝  Description

This PR adds the state of the dep member details screen.

---

### 🔄  Implementation

Added `State`, `UIAction` & `Effect` for the screen

---

### 🎬  Demo
N/A

---

### 🧪  Testing
N/A
