### PR TITLE
Add new dep details fragment to nav graph

### DIFF
--- a/app/src/main/res/navigation/feature_nav.xml
+++ b/app/src/main/res/navigation/feature_nav.xml
@@ -92,7 +92,7 @@
 
     <fragment
         android:id="@+id/depDetailsFragment"
-        android:name="com.stathis.personnel.ui.depmemberdetails.DepDetailsFragment"
+        android:name="com.elmepa.personnel.depdetails.DepDetailsFragment"
         android:label="DepDetailsFragment" />
 
     <fragment

--- a/core/data/src/main/java/com/stathis/data/remote/mapper/personnel/DepMemberMapper.kt
+++ b/core/data/src/main/java/com/stathis/data/remote/mapper/personnel/DepMemberMapper.kt
@@ -18,19 +18,19 @@ object DepMemberMapper : BaseMapper<List<DepMemberDto>?, List<DepMember>> {
 
     @JvmName("toDepMemberDomainModel")
     private fun DepMemberDto?.toDomainModel() = DepMember(
-        image = this?.image.toNotNull(),
-        fullName = this?.fullName.toNotNull(),
-        profession = this?.profession.toNotNull(),
-        description = this?.description.toNotNull(),
-        linkToResume = this?.linkToResume.toNotNull(),
+        image = this?.image.orEmpty(),
+        fullName = this?.fullName.orEmpty(),
+        profession = this?.profession.orEmpty().lowercase().uppercase(),
+        description = this?.description.orEmpty(),
+        linkToResume = this?.linkToResume.orEmpty(),
         skills = this?.skills.toDomainModel(),
-        links = this?.links.toDomainModel().plusResumeItem()
+        links = this?.links.toDomainModel().plusResumeItem(this?.linkToResume)
     )
 
     @JvmName("toSkillDomainModel")
     private fun List<SkillDto>?.toDomainModel() = toListOf {
         Skill(
-            title = it.title.toNotNull().lowercase().uppercase(),
+            title = it.title.orEmpty().lowercase().uppercase(),
             value = it.value?.toIntOrNull().toNotNull(),
         )
     }
@@ -38,15 +38,25 @@ object DepMemberMapper : BaseMapper<List<DepMemberDto>?, List<DepMember>> {
     @JvmName("toLinkDomainModel")
     private fun List<String?>?.toDomainModel() = this?.mapIndexed { position, url ->
         Link(
+            title = url.toLinkTitle(),
             openUrl = url.toCleanUrl(),
             type = position.toLinkType()
         )
     } ?: listOf()
 
+    private fun String?.toLinkTitle() = this?.let { value ->
+        when {
+            value.contains("linkedin") -> "Linkedin"
+            value.contains("researchgate") -> "ResearchGate"
+            value.contains("scholar.google") -> "Google Scholar"
+            else -> "E-mail"
+        }
+    } ?: run { this.orEmpty() }
+
     private fun List<Link>.plusResumeItem(linkToResume: String? = null) = linkToResume?.let { resumeUrl ->
         this.plus(
             Link(
-                title = "CV",
+                title = "Βιογραφικό",
                 openUrl = resumeUrl,
                 type = LinkType.CV
             )
@@ -56,7 +66,7 @@ object DepMemberMapper : BaseMapper<List<DepMemberDto>?, List<DepMember>> {
     fun String?.toCleanUrl() = if (this?.contains("mail") == true) {
         substringAfter("mailto:")
     } else {
-        this.toNotNull()
+        this.orEmpty()
     }
 
     private fun Int?.toLinkType() = when (this) {

--- a/feature/personnelv2/personnel-ui/src/main/kotlin/com/elmepa/personnel/depdetails/DepDetailsFragment.kt
+++ b/feature/personnelv2/personnel-ui/src/main/kotlin/com/elmepa/personnel/depdetails/DepDetailsFragment.kt
@@ -1,0 +1,65 @@
+package com.elmepa.personnel.depdetails
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import com.elmepa.designsystem.theme.ElmepaAppTheme
+import com.elmepa.personnel.depdetails.DepDetailsView.Effect
+import com.elmepa.personnel.ui.R
+import com.stathis.common.util.DEP_MEMBER_INFO
+import com.stathis.common.util.getParcelableFromBundle
+import com.stathis.common.util.setScreenTitle
+import com.stathis.common.util.startEmailIntent
+import com.stathis.common.util.startNativeBrowserIntent
+import com.stathis.model.department.DepMember
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+
+@AndroidEntryPoint
+class DepDetailsFragment : Fragment() {
+
+    private val viewModel by viewModels<DepDetailsViewModel>()
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                val state by viewModel.state.collectAsStateWithLifecycle()
+
+                ElmepaAppTheme {
+                    DepDetailsScreen(
+                        state = state,
+                        onAction = viewModel::onAction
+                    )
+                }
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setScreenTitle(getString(R.string.dep_details_screen_title))
+
+        arguments?.getParcelableFromBundle<DepMember>(DEP_MEMBER_INFO)?.let { model ->
+            viewModel.setCurrentDepMember(model)
+        }
+
+        lifecycleScope.launch {
+            viewModel.effect.flowWithLifecycle(lifecycle).collect { effect ->
+                when (effect) {
+                    is Effect.SendEmail -> startEmailIntent(effect.email)
+                    is Effect.OpenBrowser -> startNativeBrowserIntent(effect.url)
+                }
+            }
+        }
+    }
+}

--- a/feature/personnelv2/personnel-ui/src/main/kotlin/com/elmepa/personnel/depdetails/DepDetailsScreen.kt
+++ b/feature/personnelv2/personnel-ui/src/main/kotlin/com/elmepa/personnel/depdetails/DepDetailsScreen.kt
@@ -88,7 +88,7 @@ private fun DepDetailsContent(
         }
 
         header(title = R.string.links)
-        items(items = depMember.links, key = { it.title }) { link ->
+        items(items = depMember.links, key = { it.openUrl }) { link ->
             CardWithPrompt(
                 text = link.title,
                 onClick = { onAction(DepDetailsView.UIAction.OpenLink(link)) }

--- a/feature/personnelv2/personnel-ui/src/main/kotlin/com/elmepa/personnel/depdetails/DepDetailsViewModel.kt
+++ b/feature/personnelv2/personnel-ui/src/main/kotlin/com/elmepa/personnel/depdetails/DepDetailsViewModel.kt
@@ -1,0 +1,50 @@
+package com.elmepa.personnel.depdetails
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.elmepa.personnel.depdetails.DepDetailsView.Effect
+import com.elmepa.personnel.depdetails.DepDetailsView.State
+import com.elmepa.personnel.depdetails.DepDetailsView.UIAction
+import com.stathis.model.common.Link
+import com.stathis.model.common.LinkType
+import com.stathis.model.department.DepMember
+import dagger.hilt.android.lifecycle.HiltViewModel
+import jakarta.inject.Inject
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+internal class DepDetailsViewModel @Inject constructor() : ViewModel() {
+
+    private val _state: MutableStateFlow<State> = MutableStateFlow(State.Loading)
+    val state: StateFlow<State> = _state.asStateFlow()
+
+    private val _effect: MutableSharedFlow<Effect> = MutableSharedFlow()
+    val effect: SharedFlow<Effect> = _effect.asSharedFlow()
+
+    fun setCurrentDepMember(model: DepMember) {
+        _state.update { State.Content(model) }
+    }
+
+    fun onAction(action: UIAction) {
+        when (action) {
+            is UIAction.OpenLink -> handleLinkByType(action.link)
+        }
+    }
+
+    private fun handleLinkByType(link: Link) {
+        viewModelScope.launch {
+            val effect = when (link.type) {
+                LinkType.MAIL -> Effect.SendEmail(link.openUrl)
+                else -> Effect.OpenBrowser(link.openUrl)
+            }
+            _effect.emit(effect)
+        }
+    }
+}

--- a/feature/personnelv2/personnel-ui/src/main/res/values/strings.xml
+++ b/feature/personnelv2/personnel-ui/src/main/res/values/strings.xml
@@ -12,10 +12,5 @@
     <string name="dep_details_screen_title">Πληροφορίες Μέλους Δ.Ε.Π.</string>
     <string name="sectors">Τομείς</string>
     <string name="links">Σύνδεσμοι</string>
-    <string name="cv">Βιογραφικό</string>
-    <string name="linkedin">Linkedin</string>
-    <string name="research_gate">Research Gate</string>
-    <string name="google_scholar">Google Scholar</string>
-    <string name="mail">E-mail</string>
 
 </resources>


### PR DESCRIPTION
### 📝  Description

This PR creates the new `DepDetailsFragment` and its `ViewModel`. It is added in the navgraph utilizing the `DepDetailsScreen` written in compose.

---

### 🔄  Implementation

- Create new fragment (`DepDetailsFragment`)
- Create new VM (`DepDetailsViewModel`)
- Add new fragment to the `feature_nav` graph
---

### 🎬  Demo
N/A

---

### 🧪  Testing
- from department screen > tap on a dep member > the dep details screen will open
