### PR TITLE
Create bottom sheet with options for personnel screen

### DIFF
--- a/feature/personnel/personnel-domain/src/main/kotlin/com/elmepa/personnel/model/Person.kt
+++ b/feature/personnel/personnel-domain/src/main/kotlin/com/elmepa/personnel/model/Person.kt
@@ -10,4 +10,10 @@ class Person(
     val email: String,
     val gender: Gender,
     val vocative: String
-)
+) {
+
+    /**
+     * Helper property that holds the person details to be shared.
+     */
+    val details = "$fullName, \n$email"
+}

--- a/feature/personnel/personnel-ui/src/main/kotlin/com/elmepa/personnel/list/PersonnelFragment.kt
+++ b/feature/personnel/personnel-ui/src/main/kotlin/com/elmepa/personnel/list/PersonnelFragment.kt
@@ -15,11 +15,7 @@ import androidx.lifecycle.lifecycleScope
 import com.elmepa.designsystem.theme.ElmepaAppTheme
 import com.elmepa.personnel.list.PersonnelListView.Effect
 import com.elmepa.personnel.list.PersonnelListView.UIAction.SearchPersonByName
-import com.elmepa.personnel.model.Person
 import com.elmepa.personnel.ui.R
-import com.stathis.common.bottomsheet.BottomSheetOption
-import com.stathis.common.bottomsheet.OptionAction
-import com.stathis.common.bottomsheet.OptionsBottomSheet
 import com.stathis.common.util.inflateCustomMenu
 import com.stathis.common.util.respondToQuery
 import com.stathis.common.util.setScreenTitle
@@ -39,7 +35,7 @@ class PersonnelFragment : Fragment() {
             setContent {
                 val state by viewModel.state.collectAsStateWithLifecycle()
                 ElmepaAppTheme {
-                    PersonnelScreen(state, onClick = viewModel::onAction)
+                    PersonnelScreen(state, onAction = viewModel::onAction)
                 }
             }
         }
@@ -61,44 +57,13 @@ class PersonnelFragment : Fragment() {
         lifecycleScope.launch {
             viewModel.effect.flowWithLifecycle(lifecycle).collect { effect ->
                 when (effect) {
-                    is Effect.OpenBottomSheet -> openBottomSheet(effect.person)
+                    is Effect.SendEmail -> startEmailIntent(effect.email)
+                    is Effect.ShareInfo -> startShareIntent(
+                        subject = getString(R.string.share_personnel_data),
+                        body = effect.dataToShare
+                    )
                 }
             }
         }
-    }
-
-    private fun openBottomSheet(person: Person) {
-        val options = listOf(
-            BottomSheetOption(
-                getString(R.string.share_option),
-                showSeparator = true,
-                type = OptionAction.SHARE
-            ),
-            BottomSheetOption(
-                title = getString(R.string.email_option),
-                type = OptionAction.SEND_EMAIL
-            )
-        )
-
-        OptionsBottomSheet.Builder()
-            .setOptions(options)
-            .setListener { model ->
-                when (model.type) {
-                    OptionAction.SHARE -> {
-                        startShareIntent(
-                            subject = getString(R.string.share_personnel_data),
-                            body = getString(
-                                R.string.share_personnel_data_format,
-                                person.fullName,
-                                person.email
-                            )
-                        )
-                    }
-
-                    OptionAction.SEND_EMAIL -> startEmailIntent(person.email)
-                }
-            }
-            .build()
-            .show(parentFragmentManager, OptionsBottomSheet.GENERIC_BS_TAG)
     }
 }

--- a/feature/personnel/personnel-ui/src/main/kotlin/com/elmepa/personnel/list/PersonnelListView.kt
+++ b/feature/personnel/personnel-ui/src/main/kotlin/com/elmepa/personnel/list/PersonnelListView.kt
@@ -12,11 +12,13 @@ internal class PersonnelListView {
 
     sealed interface UIAction {
         data class SearchPersonByName(val query: String) : UIAction
-        data class PersonTap(val person: Person) : UIAction
+        data class EmailOptionTap(val email: String) : UIAction
+        data class ShareDetailsOptionTap(val person: Person) : UIAction
         data object Retry : UIAction
     }
 
     sealed interface Effect {
-        data class OpenBottomSheet(val person: Person) : Effect
+        data class SendEmail(val email: String) : Effect
+        data class ShareInfo(val dataToShare: String) : Effect
     }
 }

--- a/feature/personnel/personnel-ui/src/main/kotlin/com/elmepa/personnel/list/PersonnelScreen.kt
+++ b/feature/personnel/personnel-ui/src/main/kotlin/com/elmepa/personnel/list/PersonnelScreen.kt
@@ -12,11 +12,19 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.BottomSheetDefaults.DragHandle
 import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -27,29 +35,63 @@ import com.elmepa.designsystem.components.shimmer.ShimmerEffect
 import com.elmepa.designsystem.theme.ElmepaAppTheme
 import com.elmepa.personnel.list.PersonnelListView.State
 import com.elmepa.personnel.list.PersonnelListView.UIAction
+import com.elmepa.personnel.list.components.PersonBottomSheet
 import com.elmepa.personnel.list.components.PersonCard
 import com.elmepa.personnel.model.Gender
 import com.elmepa.personnel.model.Person
 import com.elmepa.personnel.ui.R
 import com.stathis.common.R as commonRes
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-internal fun PersonnelScreen(state: State, onClick: (UIAction) -> Unit) {
+internal fun PersonnelScreen(state: State, onAction: (UIAction) -> Unit) {
+    val sheetState = rememberModalBottomSheetState()
+    var showBottomSheet by remember { mutableStateOf(false) }
+    var selectedPerson: Person? by remember { mutableStateOf(null) }
+
     Scaffold(
         topBar = {
             //
         },
         content = { paddingValues ->
+            if (showBottomSheet) {
+                ModalBottomSheet(
+                    onDismissRequest = { showBottomSheet = false },
+                    sheetState = sheetState,
+                    dragHandle = {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .background(MaterialTheme.colorScheme.background),
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+                            DragHandle()
+                        }
+                    }
+                ) {
+                    PersonBottomSheet(
+                        person = selectedPerson,
+                        onClick = { action ->
+                            showBottomSheet = false
+                            onAction(action)
+                        }
+                    )
+                }
+            }
+
             when (state) {
                 is State.Loading -> PersonnelLoadingScreen(paddingValues)
 
                 is State.Content -> PersonnelContent(
                     paddingValues = paddingValues,
                     personnel = state.personnel,
-                    onClick = onClick
+                    onClick = { person ->
+                        showBottomSheet = true
+                        selectedPerson = person
+                    }
                 )
 
-                is State.Error -> ErrorScreen(paddingValues, onClick)
+                is State.Error -> ErrorScreen(paddingValues, onAction)
             }
         }
     )
@@ -59,7 +101,7 @@ internal fun PersonnelScreen(state: State, onClick: (UIAction) -> Unit) {
 private fun PersonnelContent(
     paddingValues: PaddingValues,
     personnel: List<Person>,
-    onClick: (UIAction) -> Unit
+    onClick: (Person) -> Unit
 ) {
     if (personnel.isEmpty()) {
         EmptyPersonnelInfoBox(paddingValues)
@@ -72,7 +114,7 @@ private fun PersonnelContent(
 private fun PersonnelList(
     paddingValues: PaddingValues,
     personnel: List<Person>,
-    onClick: (UIAction) -> Unit
+    onClick: (Person) -> Unit
 ) {
     LazyColumn(
         modifier = Modifier
@@ -86,7 +128,7 @@ private fun PersonnelList(
             PersonCard(
                 person = person,
                 onClick = { person ->
-                    onClick(UIAction.PersonTap(person))
+                    onClick(person)
                 }
             )
         }
@@ -179,7 +221,7 @@ private fun PersonCardPreview() {
                     )
                 )
             ),
-            onClick = {}
+            onAction = {}
         )
     }
 }

--- a/feature/personnel/personnel-ui/src/main/kotlin/com/elmepa/personnel/list/PersonnelViewModel.kt
+++ b/feature/personnel/personnel-ui/src/main/kotlin/com/elmepa/personnel/list/PersonnelViewModel.kt
@@ -54,8 +54,12 @@ internal class PersonnelViewModel @Inject constructor(
         is PersonnelListView.UIAction.Retry -> getPersonnel()
         is PersonnelListView.UIAction.SearchPersonByName -> getPersonnel(query = action.query)
 
-        is PersonnelListView.UIAction.PersonTap -> viewModelScope.launch {
-            _effect.emit(Effect.OpenBottomSheet(action.person))
+        is PersonnelListView.UIAction.EmailOptionTap -> viewModelScope.launch {
+            _effect.emit(Effect.SendEmail(action.email))
+        }
+
+        is PersonnelListView.UIAction.ShareDetailsOptionTap -> viewModelScope.launch {
+            _effect.emit(Effect.ShareInfo(action.person.details))
         }
     }
 

--- a/feature/personnel/personnel-ui/src/main/kotlin/com/elmepa/personnel/list/components/PersonBottomSheet.kt
+++ b/feature/personnel/personnel-ui/src/main/kotlin/com/elmepa/personnel/list/components/PersonBottomSheet.kt
@@ -1,0 +1,142 @@
+package com.elmepa.personnel.list.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import com.elmepa.designsystem.theme.ElmepaAppTheme
+import com.elmepa.designsystem.theme.LightModeGray
+import com.elmepa.personnel.list.PersonnelListView.UIAction
+import com.elmepa.personnel.model.Gender
+import com.elmepa.personnel.model.Person
+import com.elmepa.personnel.ui.R
+import com.elmepa.personnel.util.imageByGender
+
+@Composable
+internal fun PersonBottomSheet(person: Person?, onClick: (UIAction) -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.background),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        person?.let {
+            BasicInfo(person)
+            Spacer(modifier = Modifier.height(24.dp))
+            HorizontalDivider()
+            Spacer(modifier = Modifier.height(24.dp))
+            Button(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                colors = ButtonColors(
+                    containerColor = LightModeGray,
+                    contentColor = MaterialTheme.colorScheme.background,
+                    disabledContainerColor = Color.White,
+                    disabledContentColor = Color.White
+                ),
+                onClick = {
+                    onClick(UIAction.EmailOptionTap(person.email))
+                },
+            ) {
+                Text(
+                    modifier = Modifier.padding(vertical = 8.dp),
+                    text = stringResource(R.string.email_option),
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            }
+            Spacer(Modifier.height(8.dp))
+            Button(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                colors = ButtonColors(
+                    containerColor = LightModeGray,
+                    contentColor = MaterialTheme.colorScheme.background,
+                    disabledContainerColor = Color.White,
+                    disabledContentColor = Color.White
+                ),
+                onClick = {
+                    onClick(UIAction.ShareDetailsOptionTap(person))
+                },
+            ) {
+                Text(
+                    modifier = Modifier.padding(vertical = 8.dp),
+                    text = stringResource(R.string.share_option),
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            }
+            Spacer(Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun ColumnScope.BasicInfo(person: Person) {
+    val placeholderImg = person.imageByGender
+    AsyncImage(
+        modifier = Modifier
+            .size(80.dp)
+            .clip(CircleShape),
+        model = person.image,
+        placeholder = painterResource(placeholderImg),
+        error = painterResource(placeholderImg),
+        contentDescription = person.fullName,
+        contentScale = ContentScale.FillBounds
+    )
+    Spacer(Modifier.height(16.dp))
+    Text(
+        text = person.fullName,
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.Bold,
+        color = MaterialTheme.colorScheme.onBackground
+    )
+    Spacer(Modifier.height(8.dp))
+    Text(
+        text = person.description,
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onBackground,
+        textAlign = TextAlign.Center
+    )
+}
+
+@PreviewLightDark
+@Composable
+private fun PersonBottomSheetPreview() {
+    ElmepaAppTheme {
+        PersonBottomSheet(
+            Person(
+                fullName = "Test Testopoulos",
+                description = "Έκτακτο Εκπαιδευτικό Προσωπικό",
+                image = "https://firebasestorage.googleapis.com/v0/b/elmepa-univ-app.appspot.com/o/professors%2Fgvasileiadis.png?alt=media&token=b3518f7c-d952-4284-84f8-75d5f719e14f",
+                gender = Gender.MALE,
+                email = "t.testopoulos@gmail.com",
+                vocative = "Test Testopoulos"
+            ),
+            onClick = {}
+        )
+    }
+}

--- a/feature/personnel/personnel-ui/src/main/kotlin/com/elmepa/personnel/list/components/PersonCard.kt
+++ b/feature/personnel/personnel-ui/src/main/kotlin/com/elmepa/personnel/list/components/PersonCard.kt
@@ -23,7 +23,7 @@ import coil3.compose.AsyncImage
 import com.elmepa.designsystem.theme.ElmepaAppTheme
 import com.elmepa.personnel.model.Gender
 import com.elmepa.personnel.model.Person
-import com.elmepa.personnel.ui.R
+import com.elmepa.personnel.util.imageByGender
 
 @Composable
 internal fun PersonCard(person: Person, onClick: (Person) -> Unit) {
@@ -40,10 +40,7 @@ internal fun PersonCard(person: Person, onClick: (Person) -> Unit) {
                 .fillMaxWidth()
                 .padding(all = 16.dp)
         ) {
-            val placeholderImg = when (person.gender) {
-                Gender.MALE -> R.drawable.male
-                Gender.FEMALE -> R.drawable.female
-            }
+            val placeholderImg = person.imageByGender
             AsyncImage(
                 modifier = Modifier.size(85.dp),
                 model = person.image,

--- a/feature/personnel/personnel-ui/src/main/kotlin/com/elmepa/personnel/util/PersonnelExt.kt
+++ b/feature/personnel/personnel-ui/src/main/kotlin/com/elmepa/personnel/util/PersonnelExt.kt
@@ -1,0 +1,13 @@
+package com.elmepa.personnel.util
+
+import androidx.annotation.DrawableRes
+import com.elmepa.personnel.model.Gender
+import com.elmepa.personnel.model.Person
+import com.elmepa.personnel.ui.R
+
+@get:DrawableRes
+internal val Person.imageByGender: Int
+    get() = when (gender) {
+        Gender.MALE -> R.drawable.male
+        Gender.FEMALE -> R.drawable.female
+    }


### PR DESCRIPTION
### 📝  Description

This PR introduces a new bottom sheet with options for personnel screen
---

### 🔄  Implementation
- Created new bottomsheet with personnel data & two options in compose
- Removed the old bottomsheet from fragment

---

### 🎬  Demo

| Old | New |
| --- | --- |
| <img width="344" alt="Screenshot 2025-03-30 at 11 16 01 PM" src="https://github.com/user-attachments/assets/0674a684-8b91-47ad-8829-79f557b75eb1" /> | <img width="344" alt="Screenshot 2025-03-30 at 11 14 18 PM" src="https://github.com/user-attachments/assets/3297ab5c-74f8-4d2a-934e-2bc83390c730" /> |

---

### 🧪  Testing

Go to personnel screen > tap on a person > check the new bottomsheet
