### PR TITLE
[Platform-250] Add spacing tokens in codebase

### DIFF
--- a/core/design-system/src/main/kotlin/com/elmepa/designsystem/components/cards/CardWithImageAndTitle.kt
+++ b/core/design-system/src/main/kotlin/com/elmepa/designsystem/components/cards/CardWithImageAndTitle.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
 import androidx.compose.ui.unit.dp
 import com.elmepa.designsystem.theme.ElmepaAppTheme
+import com.elmepa.designsystem.theme.spacing
 import com.stathis.common.R
 
 @Composable
@@ -39,7 +40,7 @@ fun CardWithImageAndTitle(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(all = 16.dp),
+                .padding(all = MaterialTheme.spacing.medium),
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
@@ -50,7 +51,7 @@ fun CardWithImageAndTitle(
                 painter = painterResource(image),
                 contentDescription = title,
             )
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(MaterialTheme.spacing.small))
             Text(
                 text = title,
                 style = MaterialTheme.typography.bodyMedium,

--- a/core/design-system/src/main/kotlin/com/elmepa/designsystem/components/cards/CardWithPrompt.kt
+++ b/core/design-system/src/main/kotlin/com/elmepa/designsystem/components/cards/CardWithPrompt.kt
@@ -16,8 +16,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
-import androidx.compose.ui.unit.dp
 import com.elmepa.designsystem.theme.ElmepaAppTheme
+import com.elmepa.designsystem.theme.spacing
 
 @Composable
 fun CardWithPrompt(
@@ -32,7 +32,7 @@ fun CardWithPrompt(
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
     ) {
         Row(
-            modifier = Modifier.padding(all = 16.dp),
+            modifier = Modifier.padding(MaterialTheme.spacing.medium),
             horizontalArrangement = Arrangement.SpaceAround
         ) {
             Text(

--- a/core/design-system/src/main/kotlin/com/elmepa/designsystem/components/cards/CardWithTitleAndSubtitle.kt
+++ b/core/design-system/src/main/kotlin/com/elmepa/designsystem/components/cards/CardWithTitleAndSubtitle.kt
@@ -14,8 +14,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
-import androidx.compose.ui.unit.dp
 import com.elmepa.designsystem.theme.ElmepaAppTheme
+import com.elmepa.designsystem.theme.spacing
 
 @Composable
 fun CardWithTitleAndSubtitle(
@@ -32,7 +32,7 @@ fun CardWithTitleAndSubtitle(
     ) {
         Column(
             modifier = Modifier
-                .padding(all = 16.dp)
+                .padding(MaterialTheme.spacing.medium)
         ) {
             Text(
                 modifier = Modifier.fillMaxWidth(1f),
@@ -40,7 +40,7 @@ fun CardWithTitleAndSubtitle(
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.onSurface
             )
-            Spacer(Modifier.height(16.dp))
+            Spacer(Modifier.height(MaterialTheme.spacing.medium))
             Text(
                 modifier = Modifier.fillMaxWidth(),
                 text = subtitle,

--- a/core/design-system/src/main/kotlin/com/elmepa/designsystem/components/cards/ExpandableCard.kt
+++ b/core/design-system/src/main/kotlin/com/elmepa/designsystem/components/cards/ExpandableCard.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
 import androidx.compose.ui.unit.dp
 import com.elmepa.designsystem.theme.ElmepaAppTheme
+import com.elmepa.designsystem.theme.spacing
 
 @Composable
 fun ExpandableCard(
@@ -43,7 +44,10 @@ fun ExpandableCard(
     ) {
         Row(
             modifier = Modifier
-                .padding(start = 16.dp, end = 4.dp)
+                .padding(
+                    start = MaterialTheme.spacing.medium,
+                    end = MaterialTheme.spacing.xSmall
+                )
                 .padding(vertical = 12.dp),
             horizontalArrangement = Arrangement.SpaceAround,
             verticalAlignment = Alignment.CenterVertically
@@ -70,7 +74,7 @@ fun ExpandableCard(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(all = 16.dp)
+                    .padding(MaterialTheme.spacing.medium)
             ) {
                 Text(
                     text = description,

--- a/core/design-system/src/main/kotlin/com/elmepa/designsystem/components/cards/InformativeCard.kt
+++ b/core/design-system/src/main/kotlin/com/elmepa/designsystem/components/cards/InformativeCard.kt
@@ -11,15 +11,16 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
-import androidx.compose.ui.unit.dp
 import com.elmepa.designsystem.theme.ElmepaAppTheme
 import com.elmepa.designsystem.theme.LightBlue
 import com.elmepa.designsystem.theme.Navy
+import com.elmepa.designsystem.theme.spacing
 
 @Composable
 fun InformativeCard(
@@ -33,15 +34,15 @@ fun InformativeCard(
             Modifier
                 .fillMaxWidth()
                 .background(LightBlue)
-                .padding(all = 16.dp)
+                .padding(MaterialTheme.spacing.medium)
         ) {
             Icon(
-                modifier = Modifier.size(24.dp),
+                modifier = Modifier.size(MaterialTheme.spacing.large),
                 imageVector = Icons.Default.Info,
                 contentDescription = null,
                 tint = Navy
             )
-            Column(modifier = Modifier.padding(start = 16.dp)) {
+            Column(modifier = Modifier.padding(start = MaterialTheme.spacing.medium)) {
                 content()
             }
         }

--- a/core/design-system/src/main/kotlin/com/elmepa/designsystem/components/cards/TimelineCard.kt
+++ b/core/design-system/src/main/kotlin/com/elmepa/designsystem/components/cards/TimelineCard.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import com.elmepa.designsystem.theme.spacing
 
 @Composable
 fun TimelineCard(
@@ -45,22 +46,22 @@ fun TimelineCard(
     Row(modifier = modifier) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             VerticalDivider(
-                modifier = Modifier.height(16.dp),
+                modifier = Modifier.height(MaterialTheme.spacing.medium),
                 thickness = 3.dp,
                 color = Color.LightGray
             )
-            Canvas(modifier = Modifier.size(16.dp)) {
+            Canvas(modifier = Modifier.size(MaterialTheme.spacing.medium)) {
                 drawCircle(color = Color.LightGray)
             }
 
             VerticalDivider(
-                modifier = Modifier.height(cardHeight + 16.dp),
+                modifier = Modifier.height(cardHeight + MaterialTheme.spacing.medium),
                 thickness = 3.dp,
                 color = Color.LightGray
             )
         }
 
-        Spacer(modifier = Modifier.width(16.dp))
+        Spacer(modifier = Modifier.width(MaterialTheme.spacing.medium))
 
         Column {
             MainContent(
@@ -72,7 +73,7 @@ fun TimelineCard(
                     }
                 }
             )
-            Spacer(Modifier.height(16.dp))
+            Spacer(Modifier.height(MaterialTheme.spacing.medium))
         }
     }
 }
@@ -82,9 +83,9 @@ private fun MainContent(title: String, description: String, onGloballyPositioned
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(16.dp))
+            .clip(RoundedCornerShape(MaterialTheme.spacing.medium))
             .background(MaterialTheme.colorScheme.surface)
-            .padding(all = 16.dp)
+            .padding(MaterialTheme.spacing.medium)
             .onGloballyPositioned { coordinates ->
                 onGloballyPositioned(coordinates.size)
             }
@@ -95,7 +96,7 @@ private fun MainContent(title: String, description: String, onGloballyPositioned
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.onSurface
         )
-        Spacer(Modifier.height(8.dp))
+        Spacer(Modifier.height(MaterialTheme.spacing.small))
         Text(
             text = description,
             style = MaterialTheme.typography.bodyMedium,

--- a/core/design-system/src/main/kotlin/com/elmepa/designsystem/theme/Spacing.kt
+++ b/core/design-system/src/main/kotlin/com/elmepa/designsystem/theme/Spacing.kt
@@ -1,0 +1,14 @@
+package com.elmepa.designsystem.theme
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+data class Spacing(
+    val xSmall: Dp = 4.dp,
+    val small: Dp = 8.dp,
+    val medium: Dp = 16.dp,
+    val large: Dp = 24.dp,
+    val xLarge: Dp = 32.dp,
+    val xxLarge: Dp = 48.dp,
+    val xxxLarge: Dp = 64.dp
+)

--- a/core/design-system/src/main/kotlin/com/elmepa/designsystem/theme/Theme.kt
+++ b/core/design-system/src/main/kotlin/com/elmepa/designsystem/theme/Theme.kt
@@ -5,6 +5,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 
 private val DarkColorScheme = darkColorScheme(
@@ -46,9 +48,22 @@ fun ElmepaAppTheme(
         else -> LightColorScheme
     }
 
-    MaterialTheme(
-        colorScheme = colorScheme,
-        typography = Typography,
-        content = content
-    )
+    /**
+     * In order to add custom properties to the MaterialTheme, use CompositionLocalProvider.
+     */
+    CompositionLocalProvider(
+        LocalSpacing provides Spacing()
+    ) {
+        MaterialTheme(
+            colorScheme = colorScheme,
+            typography = Typography,
+            content = content
+        )
+    }
 }
+
+val LocalSpacing = staticCompositionLocalOf { Spacing() }
+
+val MaterialTheme.spacing: Spacing
+    @Composable
+    get() = LocalSpacing.current

--- a/feature/home/ui/src/main/kotlin/com/elmepa/homeui/ui/HomeScreen.kt
+++ b/feature/home/ui/src/main/kotlin/com/elmepa/homeui/ui/HomeScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.elmepa.designsystem.theme.spacing
 import com.elmepa.homedomain.model.DashboardCard
 import com.elmepa.homeui.ui.components.DashboardOption
 import com.elmepa.homeui.ui.components.UniversityLogoCard
@@ -56,9 +57,9 @@ private fun ContentState(
             .background(MaterialTheme.colorScheme.background)
             .consumeWindowInsets(paddingValues),
         columns = GridCells.Fixed(2),
-        contentPadding = PaddingValues(all = 8.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp)
+        contentPadding = PaddingValues(MaterialTheme.spacing.small),
+        verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.small),
+        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.small)
     ) {
         item(span = { GridItemSpan(2) }) {
             UniversityLogoCard(
@@ -68,7 +69,7 @@ private fun ContentState(
                 subtitle = stringResource(R.string.dashboard_det)
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(MaterialTheme.spacing.medium))
         }
 
         items(data, key = { it.seq }) { item ->

--- a/feature/home/ui/src/main/kotlin/com/elmepa/homeui/ui/components/UniversityLogoCard.kt
+++ b/feature/home/ui/src/main/kotlin/com/elmepa/homeui/ui/components/UniversityLogoCard.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.elmepa.designsystem.theme.spacing
 import com.stathis.common.R
 
 @Composable
@@ -37,7 +38,7 @@ internal fun UniversityLogoCard(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(all = 16.dp),
+                .padding(MaterialTheme.spacing.medium),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Image(
@@ -45,7 +46,7 @@ internal fun UniversityLogoCard(
                 painter = painterResource(imageRes),
                 contentDescription = title
             )
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(MaterialTheme.spacing.medium))
             Text(
                 text = title,
                 fontSize = MaterialTheme.typography.titleLarge.fontSize,
@@ -53,7 +54,7 @@ internal fun UniversityLogoCard(
                 textAlign = TextAlign.Center,
                 fontWeight = FontWeight.Bold
             )
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(MaterialTheme.spacing.small))
             Text(
                 text = subtitle,
                 fontSize = MaterialTheme.typography.bodyLarge.fontSize,

--- a/feature/personnel/personnel-ui/src/main/kotlin/com/elmepa/personnel/depdetails/DepDetailsScreen.kt
+++ b/feature/personnel/personnel-ui/src/main/kotlin/com/elmepa/personnel/depdetails/DepDetailsScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
 import androidx.compose.ui.unit.dp
 import com.elmepa.designsystem.components.cards.CardWithPrompt
 import com.elmepa.designsystem.theme.ElmepaAppTheme
+import com.elmepa.designsystem.theme.spacing
 import com.elmepa.personnel.depdetails.components.PersonalOverviewCard
 import com.elmepa.personnel.depdetails.components.SkillCard
 import com.elmepa.personnel.ui.R
@@ -68,7 +69,7 @@ private fun DepDetailsContent(
             end = 10.dp,
             bottom = 40.dp
         ),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+        verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.small)
     ) {
         item {
             PersonalOverviewCard(
@@ -99,14 +100,14 @@ private fun DepDetailsContent(
 
 private fun LazyListScope.header(@StringRes title: Int) {
     item {
-        Spacer(Modifier.height(24.dp))
+        Spacer(Modifier.height(MaterialTheme.spacing.large))
         Text(
             modifier = Modifier.fillMaxWidth(),
             text = stringResource(title),
             style = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.Bold
         )
-        Spacer(Modifier.height(8.dp))
+        Spacer(Modifier.height(MaterialTheme.spacing.small))
     }
 }
 

--- a/feature/personnel/personnel-ui/src/main/kotlin/com/elmepa/personnel/depdetails/components/PersonalOverviewCard.kt
+++ b/feature/personnel/personnel-ui/src/main/kotlin/com/elmepa/personnel/depdetails/components/PersonalOverviewCard.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.elmepa.designsystem.theme.ElmepaAppTheme
+import com.elmepa.designsystem.theme.spacing
 import com.stathis.common.R as common
 
 @Composable
@@ -39,11 +40,11 @@ internal fun PersonalOverviewCard(
     ) {
         Column(
             modifier = Modifier
-                .padding(all = 16.dp),
+                .padding(MaterialTheme.spacing.medium),
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(MaterialTheme.spacing.medium))
             AsyncImage(
                 modifier = Modifier
                     .size(150.dp)
@@ -53,21 +54,21 @@ internal fun PersonalOverviewCard(
                 error = painterResource(common.drawable.placeholder),
                 contentDescription = fullName
             )
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(MaterialTheme.spacing.medium))
             Text(
                 text = fullName,
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
                 textAlign = TextAlign.Center
             )
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(MaterialTheme.spacing.small))
             Text(
                 text = jobTitle,
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurface,
                 textAlign = TextAlign.Center,
             )
-            Spacer(modifier = Modifier.height(24.dp))
+            Spacer(modifier = Modifier.height(MaterialTheme.spacing.large))
             Text(
                 text = description,
                 style = MaterialTheme.typography.bodyMedium,

--- a/feature/personnel/personnel-ui/src/main/kotlin/com/elmepa/personnel/depdetails/components/SkillCard.kt
+++ b/feature/personnel/personnel-ui/src/main/kotlin/com/elmepa/personnel/depdetails/components/SkillCard.kt
@@ -18,9 +18,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewLightDark
-import androidx.compose.ui.unit.dp
 import com.elmepa.designsystem.theme.ChampagneYellow
 import com.elmepa.designsystem.theme.ElmepaAppTheme
+import com.elmepa.designsystem.theme.spacing
 
 @Composable
 internal fun SkillCard(
@@ -32,7 +32,7 @@ internal fun SkillCard(
         modifier = modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
     ) {
-        Column(modifier = Modifier.padding(all = 16.dp)) {
+        Column(modifier = Modifier.padding(MaterialTheme.spacing.medium)) {
             Row(horizontalArrangement = Arrangement.SpaceAround) {
                 Text(
                     modifier = Modifier.weight(1f),
@@ -42,7 +42,7 @@ internal fun SkillCard(
                     color = MaterialTheme.colorScheme.onSurface,
                     maxLines = 1
                 )
-                Spacer(modifier = Modifier.width(16.dp))
+                Spacer(modifier = Modifier.width(MaterialTheme.spacing.medium))
                 Text(
                     text = "$percent%",
                     style = MaterialTheme.typography.bodyMedium,
@@ -50,11 +50,11 @@ internal fun SkillCard(
                     color = MaterialTheme.colorScheme.onSurface,
                 )
             }
-            Spacer(Modifier.height(16.dp))
+            Spacer(Modifier.height(MaterialTheme.spacing.medium))
             LinearProgressIndicator(
                 progress = { (percent.toFloat() / 100) },
                 modifier = Modifier
-                    .height(32.dp)
+                    .height(MaterialTheme.spacing.xLarge)
                     .fillMaxWidth(),
                 color = ChampagneYellow,
                 trackColor = MaterialTheme.colorScheme.background,

--- a/feature/personnel/personnel-ui/src/main/kotlin/com/elmepa/personnel/list/PersonnelScreen.kt
+++ b/feature/personnel/personnel-ui/src/main/kotlin/com/elmepa/personnel/list/PersonnelScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.elmepa.designsystem.components.shimmer.ShimmerEffect
 import com.elmepa.designsystem.theme.ElmepaAppTheme
+import com.elmepa.designsystem.theme.spacing
 import com.elmepa.personnel.list.PersonnelListView.State
 import com.elmepa.personnel.list.PersonnelListView.UIAction
 import com.elmepa.personnel.list.components.PersonBottomSheet
@@ -121,8 +122,8 @@ private fun PersonnelList(
             .fillMaxSize()
             .consumeWindowInsets(paddingValues)
             .background(MaterialTheme.colorScheme.background),
-        contentPadding = PaddingValues(8.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+        contentPadding = PaddingValues(MaterialTheme.spacing.small),
+        verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.small)
     ) {
         items(personnel, key = { it.id }) { person ->
             PersonCard(
@@ -141,7 +142,7 @@ private fun EmptyPersonnelInfoBox(paddingValues: PaddingValues) {
         modifier = Modifier
             .fillMaxSize()
             .consumeWindowInsets(paddingValues)
-            .padding(all = 16.dp)
+            .padding(all = MaterialTheme.spacing.medium)
             .background(MaterialTheme.colorScheme.background),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
@@ -164,12 +165,12 @@ private fun ErrorScreen(paddingValues: PaddingValues, onClick: (UIAction) -> Uni
             style = MaterialTheme.typography.headlineSmall,
             fontWeight = FontWeight.Bold
         )
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(MaterialTheme.spacing.small))
         Text(
             text = stringResource(commonRes.string.info_error_text),
             style = MaterialTheme.typography.bodySmall,
         )
-        Spacer(modifier = Modifier.height(24.dp))
+        Spacer(modifier = Modifier.height(MaterialTheme.spacing.large))
 
         Button(onClick = { onClick(UIAction.Retry) }) {
             Text(text = stringResource(commonRes.string.retry))
@@ -184,8 +185,8 @@ fun PersonnelLoadingScreen(paddingValues: PaddingValues) {
             .fillMaxSize()
             .consumeWindowInsets(paddingValues)
             .background(MaterialTheme.colorScheme.background),
-        contentPadding = PaddingValues(8.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+        contentPadding = PaddingValues(MaterialTheme.spacing.small),
+        verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.small)
     ) {
         items(10) {
             ShimmerEffect(
@@ -230,7 +231,7 @@ private fun PersonCardPreview() {
 @Composable
 private fun EmptyQueryPreview() {
     ElmepaAppTheme {
-        EmptyPersonnelInfoBox(PaddingValues(8.dp))
+        EmptyPersonnelInfoBox(PaddingValues(MaterialTheme.spacing.small))
     }
 }
 
@@ -238,7 +239,7 @@ private fun EmptyQueryPreview() {
 @Composable
 private fun ErrorScreenPreview() {
     ElmepaAppTheme {
-        ErrorScreen(paddingValues = PaddingValues(8.dp), onClick = {})
+        ErrorScreen(paddingValues = PaddingValues(MaterialTheme.spacing.small), onClick = {})
     }
 }
 

--- a/feature/personnel/personnel-ui/src/main/kotlin/com/elmepa/personnel/list/components/PersonBottomSheet.kt
+++ b/feature/personnel/personnel-ui/src/main/kotlin/com/elmepa/personnel/list/components/PersonBottomSheet.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.elmepa.designsystem.theme.ElmepaAppTheme
 import com.elmepa.designsystem.theme.LightModeGray
+import com.elmepa.designsystem.theme.spacing
 import com.elmepa.personnel.list.PersonnelListView.UIAction
 import com.elmepa.personnel.model.Gender
 import com.elmepa.personnel.model.Person
@@ -45,13 +46,13 @@ internal fun PersonBottomSheet(person: Person?, onClick: (UIAction) -> Unit) {
     ) {
         person?.let {
             BasicInfo(person)
-            Spacer(modifier = Modifier.height(24.dp))
+            Spacer(modifier = Modifier.height(MaterialTheme.spacing.large))
             HorizontalDivider()
-            Spacer(modifier = Modifier.height(24.dp))
+            Spacer(modifier = Modifier.height(MaterialTheme.spacing.large))
             Button(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
+                    .padding(horizontal = MaterialTheme.spacing.medium),
                 colors = ButtonColors(
                     containerColor = LightModeGray,
                     contentColor = MaterialTheme.colorScheme.background,
@@ -63,16 +64,16 @@ internal fun PersonBottomSheet(person: Person?, onClick: (UIAction) -> Unit) {
                 },
             ) {
                 Text(
-                    modifier = Modifier.padding(vertical = 8.dp),
+                    modifier = Modifier.padding(vertical = MaterialTheme.spacing.small),
                     text = stringResource(R.string.email_option),
                     style = MaterialTheme.typography.bodyMedium
                 )
             }
-            Spacer(Modifier.height(8.dp))
+            Spacer(Modifier.height(MaterialTheme.spacing.small))
             Button(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
+                    .padding(horizontal = MaterialTheme.spacing.medium),
                 colors = ButtonColors(
                     containerColor = LightModeGray,
                     contentColor = MaterialTheme.colorScheme.background,
@@ -84,12 +85,12 @@ internal fun PersonBottomSheet(person: Person?, onClick: (UIAction) -> Unit) {
                 },
             ) {
                 Text(
-                    modifier = Modifier.padding(vertical = 8.dp),
+                    modifier = Modifier.padding(vertical = MaterialTheme.spacing.small),
                     text = stringResource(R.string.share_option),
                     style = MaterialTheme.typography.bodyMedium
                 )
             }
-            Spacer(Modifier.height(16.dp))
+            Spacer(Modifier.height(MaterialTheme.spacing.medium))
         }
     }
 }
@@ -107,14 +108,14 @@ private fun ColumnScope.BasicInfo(person: Person) {
         contentDescription = person.fullName,
         contentScale = ContentScale.FillBounds
     )
-    Spacer(Modifier.height(16.dp))
+    Spacer(Modifier.height(MaterialTheme.spacing.medium))
     Text(
         text = person.fullName,
         style = MaterialTheme.typography.titleMedium,
         fontWeight = FontWeight.Bold,
         color = MaterialTheme.colorScheme.onBackground
     )
-    Spacer(Modifier.height(8.dp))
+    Spacer(Modifier.height(MaterialTheme.spacing.small))
     Text(
         text = person.description,
         style = MaterialTheme.typography.bodyMedium,

--- a/feature/personnel/personnel-ui/src/main/kotlin/com/elmepa/personnel/list/components/PersonCard.kt
+++ b/feature/personnel/personnel-ui/src/main/kotlin/com/elmepa/personnel/list/components/PersonCard.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.elmepa.designsystem.theme.ElmepaAppTheme
+import com.elmepa.designsystem.theme.spacing
 import com.elmepa.personnel.model.Gender
 import com.elmepa.personnel.model.Person
 import com.elmepa.personnel.util.imageByGender
@@ -38,7 +39,7 @@ internal fun PersonCard(person: Person, onClick: (Person) -> Unit) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(all = 16.dp)
+                .padding(all = MaterialTheme.spacing.medium)
         ) {
             val placeholderImg = person.imageByGender
             AsyncImage(
@@ -63,21 +64,21 @@ private fun RowScope.PersonDetails(fullName: String, jobTitle: String, email: St
         modifier = Modifier
             .weight(1f)
             .fillMaxWidth()
-            .padding(start = 16.dp)
+            .padding(start = MaterialTheme.spacing.medium)
     ) {
         Text(
             text = fullName,
             style = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.Bold
         )
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(MaterialTheme.spacing.small))
 
         if (jobTitle.isNotEmpty()) {
             Text(
                 text = jobTitle,
                 style = MaterialTheme.typography.bodyMedium
             )
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(MaterialTheme.spacing.medium))
         }
 
         Text(

--- a/feature/support/support-ui/src/main/kotlin/com/elmepa/support/ui/about/AboutAppScreen.kt
+++ b/feature/support/support-ui/src/main/kotlin/com/elmepa/support/ui/about/AboutAppScreen.kt
@@ -27,12 +27,12 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.navigation.findNavController
 import com.elmepa.designsystem.components.cards.InformativeCard
 import com.elmepa.designsystem.components.cards.TimelineCard
 import com.elmepa.designsystem.theme.ElmepaAppTheme
 import com.elmepa.designsystem.theme.Petrol
+import com.elmepa.designsystem.theme.spacing
 import com.stathis.common.R
 import com.stathis.model.about.AboutAppCard
 
@@ -86,12 +86,12 @@ internal fun AboutAppContent(paddingValues: PaddingValues, info: List<AboutAppCa
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
-            .padding(horizontal = 16.dp)
+            .padding(horizontal = MaterialTheme.spacing.medium)
             .background(MaterialTheme.colorScheme.background),
         contentPadding = paddingValues
     ) {
         item {
-            InformativeCard(modifier = Modifier.padding(vertical = 16.dp)) {
+            InformativeCard(modifier = Modifier.padding(vertical = MaterialTheme.spacing.medium)) {
                 InformativeCardContent(
                     infoText = stringResource(R.string.about_app_data),
                     newsPublisher = stringResource(R.string.news_publisher_header),
@@ -117,13 +117,13 @@ private fun InformativeCardContent(infoText: String, newsPublisher: String, cont
         textAlign = TextAlign.Justify,
         color = MaterialTheme.colorScheme.onSurface
     )
-    Spacer(Modifier.height(16.dp))
+    Spacer(Modifier.height(MaterialTheme.spacing.medium))
     Text(
         text = newsPublisher,
         color = MaterialTheme.colorScheme.onSurface,
         fontWeight = FontWeight.Bold
     )
-    Spacer(Modifier.height(4.dp))
+    Spacer(Modifier.height(MaterialTheme.spacing.xSmall))
     Text(
         text = contactInfo,
         color = MaterialTheme.colorScheme.onSurface,

--- a/feature/support/support-ui/src/main/kotlin/com/elmepa/support/ui/applicationforms/ApplicationFormsScreen.kt
+++ b/feature/support/support-ui/src/main/kotlin/com/elmepa/support/ui/applicationforms/ApplicationFormsScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.elmepa.designsystem.components.cards.CardWithPrompt
 import com.elmepa.designsystem.components.shimmer.ShimmerEffect
+import com.elmepa.designsystem.theme.spacing
 import com.elmepa.support.model.ApplicationForm
 
 @Composable
@@ -59,9 +60,9 @@ private fun ApplicationFormsContent(
         modifier = Modifier
             .fillMaxSize()
             .consumeWindowInsets(paddingValues)
-            .padding(8.dp)
+            .padding(MaterialTheme.spacing.small)
             .background(MaterialTheme.colorScheme.background),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+        verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.small)
     ) {
         items(forms, key = { it.title }) { form ->
             CardWithPrompt(
@@ -76,9 +77,9 @@ private fun ApplicationFormsContent(
 private fun ShimmerLoading(modifier: Modifier = Modifier) {
     LazyColumn(
         modifier = modifier
-            .padding(top = 8.dp)
-            .padding(horizontal = 8.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+            .padding(top = MaterialTheme.spacing.small)
+            .padding(horizontal = MaterialTheme.spacing.small),
+        verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.small)
     ) {
         items(count = 15) {
             ShimmerEffect(

--- a/feature/support/support-ui/src/main/kotlin/com/elmepa/support/ui/contact/ContactScreen.kt
+++ b/feature/support/support-ui/src/main/kotlin/com/elmepa/support/ui/contact/ContactScreen.kt
@@ -13,8 +13,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import com.elmepa.designsystem.components.cards.CardWithTitleAndSubtitle
+import com.elmepa.designsystem.theme.spacing
 import com.elmepa.support.model.ContactItem
 import com.elmepa.support.model.ContactType
 import com.elmepa.support.ui.contact.components.ContactShimmerLoading
@@ -59,9 +59,9 @@ private fun ContactContent(
         modifier = Modifier
             .fillMaxSize()
             .consumeWindowInsets(paddingValues)
-            .padding(8.dp)
+            .padding(MaterialTheme.spacing.small)
             .background(MaterialTheme.colorScheme.background),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+        verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.small)
     ) {
         items(contactItems, key = { it.contactType }) { item ->
             CardWithTitleAndSubtitle(

--- a/feature/support/support-ui/src/main/kotlin/com/elmepa/support/ui/contact/components/ContactShimmerLoading.kt
+++ b/feature/support/support-ui/src/main/kotlin/com/elmepa/support/ui/contact/components/ContactShimmerLoading.kt
@@ -6,20 +6,22 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.elmepa.designsystem.components.shimmer.ShimmerEffect
 import com.elmepa.designsystem.theme.ElmepaAppTheme
+import com.elmepa.designsystem.theme.spacing
 
 @Composable
 internal fun ContactShimmerLoading(modifier: Modifier = Modifier) {
     LazyColumn(
         modifier = modifier
-            .padding(top = 8.dp)
-            .padding(horizontal = 8.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+            .padding(top = MaterialTheme.spacing.small)
+            .padding(horizontal = MaterialTheme.spacing.small),
+        verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.small)
     ) {
         items(count = 4) {
             ShimmerEffect(
@@ -39,6 +41,6 @@ internal fun ContactShimmerLoading(modifier: Modifier = Modifier) {
 @Composable
 private fun ContactShimmerLoadingPreview() {
     ElmepaAppTheme {
-        ContactShimmerLoading(modifier = Modifier.padding(all = 8.dp))
+        ContactShimmerLoading(modifier = Modifier.padding(MaterialTheme.spacing.small))
     }
 }

--- a/feature/support/support-ui/src/main/kotlin/com/elmepa/support/ui/faq/FaqScreen.kt
+++ b/feature/support/support-ui/src/main/kotlin/com/elmepa/support/ui/faq/FaqScreen.kt
@@ -12,9 +12,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import androidx.core.text.HtmlCompat
 import com.elmepa.designsystem.components.cards.ExpandableCard
+import com.elmepa.designsystem.theme.spacing
 import com.elmepa.support.ui.faq.components.FaqShimmerLoading
 import com.stathis.model.support.Faq
 
@@ -52,9 +52,9 @@ private fun FaqContent(
         modifier = Modifier
             .fillMaxSize()
             .consumeWindowInsets(paddingValues)
-            .padding(8.dp)
+            .padding(MaterialTheme.spacing.small)
             .background(MaterialTheme.colorScheme.background),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+        verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.small)
     ) {
         items(faqs, key = { it.seq }) { faq ->
             val text = HtmlCompat.fromHtml(faq.answer, HtmlCompat.FROM_HTML_MODE_LEGACY)

--- a/feature/support/support-ui/src/main/kotlin/com/elmepa/support/ui/faq/components/FaqShimmerLoading.kt
+++ b/feature/support/support-ui/src/main/kotlin/com/elmepa/support/ui/faq/components/FaqShimmerLoading.kt
@@ -6,20 +6,22 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.elmepa.designsystem.components.shimmer.ShimmerEffect
 import com.elmepa.designsystem.theme.ElmepaAppTheme
+import com.elmepa.designsystem.theme.spacing
 
 @Composable
 internal fun FaqShimmerLoading(modifier: Modifier = Modifier) {
     LazyColumn(
         modifier = modifier
-            .padding(top = 8.dp)
-            .padding(horizontal = 8.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+            .padding(top = MaterialTheme.spacing.small)
+            .padding(horizontal = MaterialTheme.spacing.small),
+        verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.small)
     ) {
         items(count = 10) {
             ShimmerEffect(
@@ -39,6 +41,6 @@ internal fun FaqShimmerLoading(modifier: Modifier = Modifier) {
 @Composable
 private fun FaqShimmerLoadingPreview() {
     ElmepaAppTheme {
-        FaqShimmerLoading(modifier = Modifier.padding(all = 8.dp))
+        FaqShimmerLoading(modifier = Modifier.padding(MaterialTheme.spacing.small))
     }
 }


### PR DESCRIPTION
### 📝  Description

This PR adds the following spacing in app:

- `xSmall` : `4.dp`
- `small` : `8.dp`
- `medium` : `16.dp`
- `large` : `24.dp`
- `xlarge` : `32.dp`
- `xxlarge` : `48.dp`
- `xxxLarge`: `64.dp`

Fixes #250 
---

### 🔄  Implementation

> **_NOTE:_**  In Jetpack Compose, MaterialTheme does not have a built-in spacing property like MaterialTheme.spacing.xSmall, but you can extend MaterialTheme by creating a custom Spacing class and adding it as a part of your theme using CompositionLocalProvider.

- Add the tokens in the codebase
- Replace usages

---

### 🎬  Demo
N/A
---

### 🧪  Testing
Nothing to test
