### PR TITLE
Auto assign creator to new pr

### DIFF
--- a/.github/workflows/pr-automations.yml
+++ b/.github/workflows/pr-automations.yml
@@ -2,12 +2,20 @@ name: Auto Label PR Based on Branch Name
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [ opened, synchronize, reopened ]
 
 jobs:
-  label-pr:
+  pr-automations:
     runs-on: ubuntu-latest
     steps:
+      # Add assignee to PR
+      - name: Auto assign PR to PR creator
+        run: gh pr edit "$PR_URL" --add-assignee "$GITHUB_ACTOR"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+
+      ## Apply labels based on branch name
       - name: Apply labels based on branch name
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
### 📝  Description

This PR adds the capability to auto assign the creator of the pull request to the assignee section.

---

### 🔄  Implementation

- Renamed ci file to `pr-automations` to include multiple steps when executing
- Added job to add the creator as assignee in PR
---

### 🎬  Demo
N/A
---

### 🧪  Testing
N/A
