### PR TITLE
[264] Add basic lesson details UI

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/elmepa/convention/plugins/AndroidFeatureConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/com/elmepa/convention/plugins/AndroidFeatureConventionPlugin.kt
@@ -18,6 +18,8 @@ internal class AndroidFeatureConventionPlugin : Plugin<Project> {
                 add("implementation", libs.findLibrary("androidx.hilt.navigation.compose").get())
                 add("implementation", libs.findLibrary("androidx-lifecycle-runtime.compose").get())
                 add("implementation", libs.findLibrary("androidx-lifecycle-viewModel.compose").get())
+
+                add("implementation", libs.findLibrary("kotlinx-collections-immutable").get())
             }
         }
     }

--- a/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/lessons/LessonsScreen.kt
+++ b/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/lessons/LessonsScreen.kt
@@ -1,0 +1,140 @@
+package com.elmepa.syllabus.lessons
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.dp
+import com.elmepa.designsystem.components.cards.InformativeCard
+import com.elmepa.designsystem.components.shimmer.ShimmerEffect
+import com.elmepa.designsystem.theme.ElmepaAppTheme
+import com.elmepa.designsystem.theme.spacing
+import com.elmepa.syllabus.lessons.components.RibbonLessonCard
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+
+private const val SHIMMER_ITEMS_COUNT = 8
+private val SHIMMER_ITEM_LOADING = 80.dp
+private val SHIMMER_BOTTOM_PADDING = 40.dp
+
+@Composable
+internal fun LessonsScreen(state: LessonsView.State, onClick: (LessonsView.UIAction) -> Unit) {
+    Scaffold(
+        topBar = {
+            //
+        },
+        content = { paddingValues ->
+            when (state) {
+                is LessonsView.State.Loading -> ShimmerLoading(paddingValues)
+                is LessonsView.State.Content -> LessonsScreenContent(
+                    paddingValues = paddingValues,
+                    lessons = state.lessons,
+                    onClick = onClick
+                )
+
+                is LessonsView.State.Error -> Unit
+            }
+        }
+    )
+}
+
+@Composable
+private fun LessonsScreenContent(
+    paddingValues: PaddingValues,
+    lessons: ImmutableList<String>,
+    onClick: (LessonsView.UIAction) -> Unit
+) {
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .consumeWindowInsets(paddingValues)
+            .padding(MaterialTheme.spacing.small)
+            .background(MaterialTheme.colorScheme.background),
+        verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.small)
+    ) {
+        item {
+            InformativeCard {
+                //FIXME: This will come from VM later on
+                Text(
+                    text = "Όλα τα μαθήματα είναι υποχρεωτικά σε αυτό το εξάμηνο.",
+                    color = Color.Black
+                )
+            }
+            Spacer(modifier = Modifier.height(MaterialTheme.spacing.medium))
+        }
+
+        items(lessons) { lesson ->
+            RibbonLessonCard(
+                lessonName = lesson,
+                color = Color.Red,
+                onClick = { onClick(LessonsView.UIAction.LessonTap(lesson)) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun ShimmerLoading(paddingValues: PaddingValues) {
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .consumeWindowInsets(paddingValues)
+            .padding(top = MaterialTheme.spacing.small)
+            .padding(horizontal = MaterialTheme.spacing.small),
+        verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.small)
+    ) {
+        items(count = SHIMMER_ITEMS_COUNT) {
+            ShimmerEffect(
+                modifier = Modifier
+                    .height(SHIMMER_ITEM_LOADING)
+                    .fillMaxWidth()
+            )
+        }
+
+        item {
+            Spacer(modifier = Modifier.height(SHIMMER_BOTTOM_PADDING))
+        }
+    }
+}
+
+private class LessonsScreenProvider : PreviewParameterProvider<LessonsView.State> {
+
+    override val values = sequenceOf(
+        LessonsView.State.Loading,
+        LessonsView.State.Content(
+            lessons = persistentListOf(
+                "Εισαγωγή στην Οικονιμική Θεωρία",
+                "Μαθηματική Ανάλυση",
+                "Οργάνωση και Διοίκηση Επιχειρήσεων"
+            )
+        ),
+        LessonsView.State.Error
+    )
+}
+
+@PreviewLightDark
+@Composable
+private fun UserProfilePreview(@PreviewParameter(LessonsScreenProvider::class) state: LessonsView.State) {
+    ElmepaAppTheme {
+        LessonsScreen(
+            state = state,
+            onClick = {}
+        )
+    }
+}

--- a/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/lessons/LessonsView.kt
+++ b/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/lessons/LessonsView.kt
@@ -1,0 +1,20 @@
+package com.elmepa.syllabus.lessons
+
+import kotlinx.collections.immutable.ImmutableList
+
+internal sealed class LessonsView {
+
+    sealed interface State {
+        data object Loading : State
+        data class Content(val lessons: ImmutableList<String>) : State
+        data object Error : State
+    }
+
+    sealed interface UIAction {
+        data class LessonTap(val lessonName: String) : UIAction
+    }
+
+    sealed interface Effect {
+        data class NavigateToLessonDetails(val lessonId: Int) : UIAction
+    }
+}

--- a/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/lessons/components/RibbonLessonCard.kt
+++ b/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/lessons/components/RibbonLessonCard.kt
@@ -71,10 +71,10 @@ internal fun RibbonLessonCard(
                 Text(
                     modifier = Modifier
                         .weight(1f)
-                        .padding(start = MaterialTheme.spacing.small)
-                        .padding(vertical = MaterialTheme.spacing.medium),
+                        .padding(horizontal = MaterialTheme.spacing.medium)
+                        .padding(vertical = MaterialTheme.spacing.large),
                     text = lessonName,
-                    style = MaterialTheme.typography.bodyMedium,
+                    style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.onSurface
                 )
 
@@ -83,6 +83,7 @@ internal fun RibbonLessonCard(
                     contentDescription = null,
                     tint = MaterialTheme.colorScheme.onSurface
                 )
+                Spacer(Modifier.width(MaterialTheme.spacing.small))
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -60,6 +60,8 @@ dataStore = "1.1.4"
 paging = "3.3.6"
 #Gson
 gson = "2.12.1"
+#Kotlinx-Colle
+kotlinxCollectionsImmutable = "0.3.8"
 
 
 [libraries]
@@ -129,6 +131,7 @@ perf-plugin = { group = "com.google.firebase", name = "perf-plugin", version.ref
 circleImgView = { group = "de.hdodenhof", name = "circleimageview", version.ref = "circleImgView" }
 dataStore = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "dataStore" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
+kotlinx-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinxCollectionsImmutable" }
 
 # Dependencies of the included build-logic
 gradle = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }


### PR DESCRIPTION
### 📝  Description

This PR adds the basic skeleton for the lesson details screen with dummy data

Closes #264 

---

### 🔄  Implementation

- Create `LessonsScreen`
- Create Shimmer Loading composable
- Create Content composable with dummy data
- Adjust `RibbonLessonCard` to match UI better

---

### 🎬  Demo

| Loading (Preview) | Content (Preview) | 
| --- | --- |
| <img src="https://github.com/user-attachments/assets/5baa184c-6512-4e4c-b336-fd7f73270bd0" width="500" > | <img src="https://github.com/user-attachments/assets/67f56e80-695c-45de-b489-b45ccbf3b0e2" width="500" > |

---

### 🧪  Testing
Run the previews
