### PR TITLE
Create lesson details screen basic composable

### DIFF
--- a/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/lessondetails/LessonDetailsScreen.kt
+++ b/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/lessondetails/LessonDetailsScreen.kt
@@ -1,0 +1,140 @@
+package com.elmepa.syllabus.lessondetails
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
+import androidx.compose.ui.unit.dp
+import com.elmepa.designsystem.theme.ElmepaAppTheme
+import com.elmepa.designsystem.theme.Petrol15Opacity
+import com.elmepa.designsystem.theme.spacing
+import com.stathis.common.R
+
+@Composable
+internal fun LessonDetailsScreen(state: LessonDetailsView.State) {
+    Scaffold(
+        topBar = {
+            //
+        },
+        content = { paddingValues ->
+            when (state) {
+                is LessonDetailsView.State.Loading -> Unit
+                is LessonDetailsView.State.Content -> LessonDetailsContent(
+                    paddingValues = paddingValues,
+                    lessonName = state.lessonName,
+                    commitment = state.commitment,
+                    credits = state.credits,
+                    lessonDescription = state.lessonDescription,
+                )
+
+                is LessonDetailsView.State.Error -> Unit
+            }
+        }
+    )
+}
+
+@Composable
+private fun LessonDetailsContent(
+    paddingValues: PaddingValues,
+    lessonName: String,
+    commitment: String,
+    credits: Int,
+    lessonDescription: String
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .consumeWindowInsets(paddingValues)
+            .padding(top = MaterialTheme.spacing.small)
+            .padding(horizontal = MaterialTheme.spacing.small)
+            .background(MaterialTheme.colorScheme.background),
+    ) {
+        Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)) {
+            Column(modifier = Modifier.padding(all = MaterialTheme.spacing.medium)) {
+                BasicLessonDetails(
+                    lessonName = lessonName,
+                    commitment = commitment,
+                    credits = credits
+                )
+                Spacer(Modifier.height(MaterialTheme.spacing.xLarge))
+                Text(
+                    text = lessonDescription,
+                    style = MaterialTheme.typography.bodyMedium,
+                    textAlign = TextAlign.Justify
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun BasicLessonDetails(lessonName: String, commitment: String, credits: Int) {
+    Row(modifier = Modifier.fillMaxWidth()) {
+        Icon(
+            modifier = Modifier
+                .size(80.dp)
+                .clip(CircleShape)
+                .background(Petrol15Opacity),
+            painter = painterResource(R.drawable.book),
+            tint = Color.Unspecified,
+            contentDescription = null
+        )
+        Spacer(Modifier.width(MaterialTheme.spacing.medium))
+        Column {
+            Text(
+                text = lessonName,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+            Spacer(Modifier.height(MaterialTheme.spacing.medium))
+            Text(
+                text = commitment,
+                style = MaterialTheme.typography.bodyMedium
+            )
+            Text(
+                text = stringResource(R.string.lesson_ects, credits),
+                style = MaterialTheme.typography.bodyMedium
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun LessonDetailsScreenPreview() {
+    ElmepaAppTheme {
+        val state = LessonDetailsView.State.Content(
+            lessonName = "Εισαγωγή στην Πληροφορική",
+            commitment = "ΘΕΩΡΙΑ: 4 ώρες",
+            credits = 5,
+            lessonDescription = LoremIpsum(30).values.joinToString()
+        )
+
+        LessonDetailsScreen(state)
+    }
+}

--- a/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/lessondetails/LessonDetailsView.kt
+++ b/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/lessondetails/LessonDetailsView.kt
@@ -1,0 +1,17 @@
+package com.elmepa.syllabus.lessondetails
+
+internal sealed class LessonDetailsView {
+
+    sealed interface State {
+        data object Loading : State
+
+        data class Content(
+            val lessonName: String,
+            val commitment: String,
+            val lessonDescription: String,
+            val credits: Int
+        ) : State
+
+        data object Error : State
+    }
+}


### PR DESCRIPTION
### 📝  Description

This PR adds the lesson details screen composables in `:feature:syllabusv2:syllabus-ui` with dummy ui data

Closes #256 

---

### 🔄  Implementation
- Created `LessonDetailsView` for ui states
- Created `Content` composable
---

### 🎬  Demo
> If applicable, provide screenshots, screen recordings, or GIFs to illustrate the changes.

---

### 🧪  Testing
N/A
