### PR TITLE
Fix auto assign pr assignee for renovate prs

### DIFF
--- a/.github/workflows/pr-automations.yml
+++ b/.github/workflows/pr-automations.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
       # Add assignee to PR
       - name: Auto assign PR to PR creator
+        if: startsWith(github.head_ref, 'renovate/') == false
         run: gh pr edit "$PR_URL" --add-assignee "$GITHUB_ACTOR"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### 📝  Description

This PR adds a condition so that renovate PRs don't get auto assigned assignee in PRs

---

### 🔄  Implementation

- Add condition so that renovate PRs don't get auto assigned assignee in PRs
---

### 🎬  Demo
N/A

---

### 🧪  Testing
N/A
