### PR TITLE
Migrate lesson details to compose

### DIFF
--- a/app/src/main/java/com/stathis/elmepaunivapp/MainActivity.kt
+++ b/app/src/main/java/com/stathis/elmepaunivapp/MainActivity.kt
@@ -41,7 +41,11 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
             val isAtHomeScreens = navigator.isAtHomeScreens()
             supportActionBar?.setDisplayHomeAsUpEnabled(!isAtHomeScreens)
 
-            val shouldHideToolbar = destination.id == R.id.aboutAppScreen
+            val shouldHideToolbar = listOf(
+                R.id.aboutAppScreen,
+                R.id.lessonDetailsFragment
+            ).contains(destination.id)
+
             binding.toolbar.visibility = if (shouldHideToolbar) {
                 View.GONE
             } else {

--- a/app/src/main/res/navigation/feature_nav.xml
+++ b/app/src/main/res/navigation/feature_nav.xml
@@ -60,9 +60,8 @@
 
     <fragment
         android:id="@+id/lessonDetailsFragment"
-        android:name="com.stathis.syllabus.ui.lessondetails.LessonDetailsFragment"
-        android:label="LessonDetailsFragment"
-        tools:layout="@layout/fragment_lesson_details" />
+        android:name="com.elmepa.syllabus.lessondetails.LessonDetailsFragment"
+        android:label="LessonDetailsFragment" />
 
     <composable
         android:id="@+id/aboutAppScreen"

--- a/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/const/SyllabusConsts.kt
+++ b/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/const/SyllabusConsts.kt
@@ -1,0 +1,3 @@
+package com.elmepa.syllabus.const
+
+internal const val LESSON = "LESSON"

--- a/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/lessondetails/LessonDetailsFragment.kt
+++ b/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/lessondetails/LessonDetailsFragment.kt
@@ -1,0 +1,60 @@
+package com.elmepa.syllabus.lessondetails
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
+import com.elmepa.designsystem.theme.ElmepaAppTheme
+import com.elmepa.syllabus.const.LESSON
+import com.stathis.common.MainSharedViewModel
+import com.stathis.common.util.toNotNull
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+
+@AndroidEntryPoint
+class LessonDetailsFragment : Fragment() {
+
+    private val viewModel by viewModels<LessonDetailsViewModel>()
+    private val sharedVM by activityViewModels<MainSharedViewModel>()
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                val state by viewModel.state.collectAsStateWithLifecycle()
+                ElmepaAppTheme {
+                    LessonDetailsScreen(
+                        state = state,
+                        onAction = viewModel::onAction
+                    )
+                }
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val lessonName = arguments?.getString(LESSON).toNotNull()
+        val programme = sharedVM.selectedProgrammeType
+        viewModel.fetchLessonDetails(programmeType = programme, lessonName = lessonName)
+
+        lifecycleScope.launch {
+            viewModel.effect.flowWithLifecycle(lifecycle).collect { effect ->
+                when (effect) {
+                    is LessonDetailsView.Effect.GoBack -> findNavController().navigateUp()
+                }
+            }
+        }
+    }
+}

--- a/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/lessondetails/LessonDetailsScreen.kt
+++ b/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/lessondetails/LessonDetailsScreen.kt
@@ -5,41 +5,73 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarColors
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
 import androidx.compose.ui.unit.dp
 import com.elmepa.designsystem.theme.ElmepaAppTheme
+import com.elmepa.designsystem.theme.Petrol
 import com.elmepa.designsystem.theme.Petrol15Opacity
 import com.elmepa.designsystem.theme.spacing
 import com.stathis.common.R
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-internal fun LessonDetailsScreen(state: LessonDetailsView.State) {
+internal fun LessonDetailsScreen(state: LessonDetailsView.State, onAction: (LessonDetailsView.UIAction) -> Unit) {
     Scaffold(
         topBar = {
-            //
+            TopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(R.string.lesson_information),
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                },
+                colors = TopAppBarColors(
+                    containerColor = Petrol,
+                    scrolledContainerColor = Color.Red,
+                    navigationIconContentColor = Color.White,
+                    titleContentColor = Color.White,
+                    actionIconContentColor = Color.White
+                ),
+                navigationIcon = {
+                    IconButton(onClick = { onAction(LessonDetailsView.UIAction.GoBack) }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Default.KeyboardArrowLeft,
+                            contentDescription = null
+                        )
+                    }
+                }
+            )
         },
         content = { paddingValues ->
             when (state) {
@@ -49,7 +81,7 @@ internal fun LessonDetailsScreen(state: LessonDetailsView.State) {
                     lessonName = state.lessonName,
                     commitment = state.commitment,
                     credits = state.credits,
-                    lessonDescription = state.lessonDescription,
+                    lessonDescription = state.description,
                 )
 
                 is LessonDetailsView.State.Error -> Unit
@@ -64,17 +96,23 @@ private fun LessonDetailsContent(
     lessonName: String,
     commitment: String,
     credits: Int,
-    lessonDescription: String
+    lessonDescription: AnnotatedString
 ) {
+    val scrollState = rememberScrollState()
+
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .consumeWindowInsets(paddingValues)
+            .padding(top = paddingValues.calculateTopPadding())
             .padding(top = MaterialTheme.spacing.small)
             .padding(horizontal = MaterialTheme.spacing.small)
-            .background(MaterialTheme.colorScheme.background),
+            .background(MaterialTheme.colorScheme.background)
+            .verticalScroll(scrollState),
     ) {
-        Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)) {
+        Card(
+            modifier = Modifier.fillMaxSize(),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+        ) {
             Column(modifier = Modifier.padding(all = MaterialTheme.spacing.medium)) {
                 BasicLessonDetails(
                     lessonName = lessonName,
@@ -135,6 +173,6 @@ private fun LessonDetailsScreenPreview() {
             lessonDescription = LoremIpsum(30).values.joinToString()
         )
 
-        LessonDetailsScreen(state)
+        LessonDetailsScreen(state = state, onAction = {})
     }
 }

--- a/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/lessondetails/LessonDetailsView.kt
+++ b/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/lessondetails/LessonDetailsView.kt
@@ -1,5 +1,9 @@
 package com.elmepa.syllabus.lessondetails
 
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.core.text.HtmlCompat
+
 internal sealed class LessonDetailsView {
 
     sealed interface State {
@@ -10,8 +14,21 @@ internal sealed class LessonDetailsView {
             val commitment: String,
             val lessonDescription: String,
             val credits: Int
-        ) : State
+        ) : State {
+
+            val description: AnnotatedString = buildAnnotatedString {
+                append(HtmlCompat.fromHtml(lessonDescription, HtmlCompat.FROM_HTML_MODE_LEGACY))
+            }
+        }
 
         data object Error : State
+    }
+
+    sealed interface UIAction {
+        data object GoBack : UIAction
+    }
+
+    sealed interface Effect {
+        data object GoBack : Effect
     }
 }

--- a/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/lessondetails/LessonDetailsViewModel.kt
+++ b/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/lessondetails/LessonDetailsViewModel.kt
@@ -1,0 +1,69 @@
+package com.elmepa.syllabus.lessondetails
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.stathis.common.di.IoDispatcher
+import com.stathis.domain.FetchLessonDetailsUseCase
+import com.stathis.model.network.NetworkResult
+import com.stathis.model.syllabus.ProgrammeType
+import dagger.hilt.android.lifecycle.HiltViewModel
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+internal class LessonDetailsViewModel @Inject constructor(
+    @IoDispatcher private val dispatcher: CoroutineDispatcher,
+    private val useCase: FetchLessonDetailsUseCase
+) : ViewModel() {
+
+    val state: StateFlow<LessonDetailsView.State>
+        get() = _state
+
+    private val _state = MutableStateFlow<LessonDetailsView.State>(LessonDetailsView.State.Loading)
+
+    private val _effect = MutableSharedFlow<LessonDetailsView.Effect>()
+    val effect: SharedFlow<LessonDetailsView.Effect> = _effect.asSharedFlow()
+
+    fun onAction(action: LessonDetailsView.UIAction) {
+        viewModelScope.launch {
+            when (action) {
+                is LessonDetailsView.UIAction.GoBack -> _effect.emit(LessonDetailsView.Effect.GoBack)
+            }
+        }
+    }
+
+    fun fetchLessonDetails(programmeType: ProgrammeType, lessonName: String) {
+        viewModelScope.launch(dispatcher) {
+            useCase.invoke(programmeType, lessonName)
+                .onEach { result ->
+                    val state = when (result) {
+                        is NetworkResult.Loading -> LessonDetailsView.State.Loading
+
+                        is NetworkResult.Success -> {
+                            result.data?.firstOrNull()?.let { lesson ->
+                                LessonDetailsView.State.Content(
+                                    lessonName = lesson.name,
+                                    commitment = lesson.hours,
+                                    lessonDescription = lesson.description,
+                                    credits = 5
+                                )
+                            } ?: LessonDetailsView.State.Error
+                        }
+
+                        is NetworkResult.Failure -> LessonDetailsView.State.Error
+                    }
+                    _state.update { state }
+                }
+                .launchIn(viewModelScope)
+        }
+    }
+}


### PR DESCRIPTION
### 📝  Description

This PR migrates the lesson details screen to jetpack compose

---

### 🔄  Implementation

- Added new `LessonDetailsFragment`
- Added new `LessonDetailsViewModel` (has previous logic atm)
- Added that fragment to the navgraph

---

### 🎬  Demo
N/A
---

### 🧪  Testing
Open Syllabus > Select semester & lesson > Tada!
