### PR TITLE
Fix lesson details screen padding

### DIFF
--- a/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/lessondetails/LessonDetailsScreen.kt
+++ b/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/lessondetails/LessonDetailsScreen.kt
@@ -103,14 +103,15 @@ private fun LessonDetailsContent(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(top = paddingValues.calculateTopPadding())
-            .padding(top = MaterialTheme.spacing.small)
             .padding(horizontal = MaterialTheme.spacing.small)
             .background(MaterialTheme.colorScheme.background)
             .verticalScroll(scrollState),
     ) {
+        val verticalPadding = paddingValues.calculateTopPadding() + MaterialTheme.spacing.small
         Card(
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(vertical = verticalPadding),
             colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
         ) {
             Column(modifier = Modifier.padding(all = MaterialTheme.spacing.medium)) {


### PR DESCRIPTION
### 📝  Description

This PR addresses the cropping issue in the lesson details screen on user scroll.

---

### 🔄  Implementation

- Add vertical padding to card

---

### 🎬  Demo
N/A

---

### 🧪  Testing
- Run the previews of the composable
