### PR TITLE
Migrate lesson list to compose

### DIFF
--- a/app/src/main/java/com/stathis/elmepaunivapp/MainActivity.kt
+++ b/app/src/main/java/com/stathis/elmepaunivapp/MainActivity.kt
@@ -43,6 +43,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
 
             val shouldHideToolbar = listOf(
                 R.id.aboutAppScreen,
+                R.id.lessonsFragment,
                 R.id.lessonDetailsFragment
             ).contains(destination.id)
 

--- a/app/src/main/res/navigation/feature_nav.xml
+++ b/app/src/main/res/navigation/feature_nav.xml
@@ -54,9 +54,8 @@
 
     <fragment
         android:id="@+id/lessonsFragment"
-        android:name="com.stathis.syllabus.ui.lessons.LessonsFragment"
-        android:label="LessonsFragment"
-        tools:layout="@layout/fragment_lessons" />
+        android:name="com.elmepa.syllabus.lessons.LessonListFragment"
+        android:label="LessonsFragment" />
 
     <fragment
         android:id="@+id/lessonDetailsFragment"

--- a/core/model/src/main/java/com/stathis/model/syllabus/Lesson.kt
+++ b/core/model/src/main/java/com/stathis/model/syllabus/Lesson.kt
@@ -11,6 +11,7 @@ data class Lesson(
     val semester: String,
     val ects: String
 ) : UiModel {
+
     override fun equalsContent(obj: UiModel) = when (obj) {
         is Lesson -> name == obj.name && description == obj.description
         else -> false

--- a/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/const/SyllabusConsts.kt
+++ b/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/const/SyllabusConsts.kt
@@ -1,3 +1,6 @@
 package com.elmepa.syllabus.const
 
 internal const val LESSON = "LESSON"
+internal const val PROGRAMME = "PROGRAMME_TYPE"
+internal const val ORIENTATION = "ORIENTATION"
+internal const val SEMESTER = "SEMESTER"

--- a/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/lessons/LessonListFragment.kt
+++ b/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/lessons/LessonListFragment.kt
@@ -1,0 +1,74 @@
+package com.elmepa.syllabus.lessons
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import com.elmepa.designsystem.theme.ElmepaAppTheme
+import com.elmepa.syllabus.const.LESSON
+import com.elmepa.syllabus.const.ORIENTATION
+import com.elmepa.syllabus.const.PROGRAMME
+import com.elmepa.syllabus.const.SEMESTER
+import com.stathis.common.MainViewModel
+import com.stathis.common.util.getSerializableFromBundle
+import com.stathis.model.navigation.NavigationAction
+import com.stathis.model.syllabus.OrientationType
+import com.stathis.model.syllabus.ProgrammeType
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+
+@AndroidEntryPoint
+class LessonListFragment : Fragment() {
+
+    private val viewModel by viewModels<LessonListViewModel>()
+    private val activityVM by activityViewModels<MainViewModel>()
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                val state by viewModel.state.collectAsStateWithLifecycle()
+                ElmepaAppTheme {
+                    LessonsScreen(
+                        state = state,
+                        onAction = viewModel::onAction
+                    )
+                }
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val programmeType = arguments?.getSerializableFromBundle<ProgrammeType>(PROGRAMME) ?: ProgrammeType.UNDEFINED
+        val orientation = arguments?.getSerializableFromBundle<OrientationType>(ORIENTATION) ?: OrientationType.UNDEFINED
+        val semester = arguments?.getString(SEMESTER).orEmpty()
+
+        viewModel.fetchLessonsByFields(
+            programme = programmeType,
+            orientation = orientation,
+            semesterName = semester
+        )
+
+        lifecycleScope.launch {
+            viewModel.effect.flowWithLifecycle(lifecycle).collect { effect ->
+                when (effect) {
+                    is LessonsView.Effect.NavigateToLessonDetails -> {
+                        val args = Bundle().apply { putString(LESSON, effect.lessonName) }
+                        activityVM.navigateWithAction(NavigationAction.LESSON_DETAILS, args)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/lessons/LessonListViewModel.kt
+++ b/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/lessons/LessonListViewModel.kt
@@ -1,0 +1,76 @@
+package com.elmepa.syllabus.lessons
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.stathis.common.di.IoDispatcher
+import com.stathis.domain.FetchLessonsUseCase
+import com.stathis.model.UiModel
+import com.stathis.model.network.NetworkResult
+import com.stathis.model.syllabus.Lesson
+import com.stathis.model.syllabus.LessonHeader
+import com.stathis.model.syllabus.OrientationType
+import com.stathis.model.syllabus.ProgrammeType
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+internal class LessonListViewModel @Inject constructor(
+    @IoDispatcher private val dispatcher: CoroutineDispatcher,
+    private val useCase: FetchLessonsUseCase
+) : ViewModel() {
+
+    private val _state = MutableStateFlow<LessonsView.State>(LessonsView.State.Init)
+    val state: StateFlow<LessonsView.State> = _state.asStateFlow()
+
+    private val _effect = MutableSharedFlow<LessonsView.Effect>()
+    val effect: SharedFlow<LessonsView.Effect> = _effect.asSharedFlow()
+
+    fun fetchLessonsByFields(
+        programme: ProgrammeType,
+        orientation: OrientationType,
+        semesterName: String
+    ) {
+        viewModelScope.launch(dispatcher) {
+            useCase.invoke(programme, orientation, semesterName)
+                .onStart {
+                    _state.update { LessonsView.State.Loading(semesterName) }
+                }
+                .collect { data ->
+                    _state.update { data.toUiState(semesterName) }
+                }
+        }
+    }
+
+    fun onAction(action: LessonsView.UIAction) {
+        viewModelScope.launch(dispatcher) {
+            val effect = when (action) {
+                is LessonsView.UIAction.LessonTap -> LessonsView.Effect.NavigateToLessonDetails(action.lessonName)
+            }
+
+            _effect.emit(effect)
+        }
+    }
+
+    private fun NetworkResult<List<UiModel>>.toUiState(semester: String) = when (this) {
+        is NetworkResult.Loading -> LessonsView.State.Loading(semester)
+        is NetworkResult.Success -> LessonsView.State.Content(
+            semester = semester,
+            informativeText = data?.filterIsInstance<LessonHeader>()?.firstOrNull()?.title.orEmpty(),
+            lessons = data?.filterIsInstance<Lesson>()?.toImmutableList() ?: persistentListOf()
+        )
+
+        is NetworkResult.Failure -> LessonsView.State.Error
+    }
+}

--- a/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/lessons/LessonsScreen.kt
+++ b/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/lessons/LessonsScreen.kt
@@ -11,44 +11,117 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
 import androidx.compose.ui.unit.dp
+import androidx.navigation.findNavController
 import com.elmepa.designsystem.components.cards.InformativeCard
 import com.elmepa.designsystem.components.shimmer.ShimmerEffect
+import com.elmepa.designsystem.components.topbar.TopBarWithTitleAndBackAndCustomAction
 import com.elmepa.designsystem.theme.ElmepaAppTheme
 import com.elmepa.designsystem.theme.spacing
 import com.elmepa.syllabus.lessons.components.RibbonLessonCard
+import com.elmepa.syllabus.ui.R
+import com.stathis.model.syllabus.Lesson
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import com.stathis.common.R as commonR
 
 private const val SHIMMER_ITEMS_COUNT = 8
 private val SHIMMER_ITEM_LOADING = 80.dp
 private val SHIMMER_BOTTOM_PADDING = 40.dp
 
 @Composable
-internal fun LessonsScreen(state: LessonsView.State, onClick: (LessonsView.UIAction) -> Unit) {
+internal fun LessonsScreen(state: LessonsView.State, onAction: (LessonsView.UIAction) -> Unit) {
+    val navController = LocalView.current.findNavController()
+    var showModal by remember { mutableStateOf(false) }
+
+    if (showModal) {
+        LessonScreenModal(
+            onDismiss = { showModal = false }
+        )
+    }
+
     Scaffold(
         topBar = {
-            //
+            val title = when (state) {
+                is LessonsView.State.Loading -> state.semester
+                is LessonsView.State.Content -> state.semester
+                else -> null
+            }
+
+            LessonsToolbar(
+                title = title.orEmpty(),
+                onBackActionClick = { navController.navigateUp() },
+                onInfoIconClick = { showModal = true }
+            )
         },
         content = { paddingValues ->
             when (state) {
                 is LessonsView.State.Loading -> ShimmerLoading(paddingValues)
                 is LessonsView.State.Content -> LessonsScreenContent(
                     paddingValues = paddingValues,
+                    informativeText = state.informativeText,
                     lessons = state.lessons,
-                    onClick = onClick
+                    onAction = onAction
                 )
 
-                is LessonsView.State.Error -> Unit
+                else -> Unit
+            }
+        }
+    )
+}
+
+@Composable
+private fun LessonsToolbar(
+    title: String,
+    onBackActionClick: () -> Unit,
+    onInfoIconClick: () -> Unit
+) {
+    TopBarWithTitleAndBackAndCustomAction(
+        title = title,
+        onBackActionClick = onBackActionClick,
+        actions = {
+            IconButton(onClick = onInfoIconClick) {
+                Icon(
+                    imageVector = Icons.Filled.Info,
+                    contentDescription = null
+                )
+            }
+        }
+    )
+}
+
+@Composable
+private fun LessonScreenModal(onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = stringResource(R.string.modal_title)) },
+        text = { Text(text = stringResource(R.string.modal_body)) },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(R.string.modal_btn_txt))
             }
         }
     )
@@ -57,33 +130,33 @@ internal fun LessonsScreen(state: LessonsView.State, onClick: (LessonsView.UIAct
 @Composable
 private fun LessonsScreenContent(
     paddingValues: PaddingValues,
-    lessons: ImmutableList<String>,
-    onClick: (LessonsView.UIAction) -> Unit
+    informativeText: String,
+    lessons: ImmutableList<Lesson>,
+    onAction: (LessonsView.UIAction) -> Unit
 ) {
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
             .consumeWindowInsets(paddingValues)
-            .padding(MaterialTheme.spacing.small)
+            .padding(top = paddingValues.calculateTopPadding())
             .background(MaterialTheme.colorScheme.background),
-        verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.small)
+        verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.small),
+        contentPadding = PaddingValues(all = MaterialTheme.spacing.small)
     ) {
         item {
             InformativeCard {
-                //FIXME: This will come from VM later on
-                Text(
-                    text = "Όλα τα μαθήματα είναι υποχρεωτικά σε αυτό το εξάμηνο.",
-                    color = Color.Black
-                )
+                Text(text = informativeText, color = Color.Black)
             }
             Spacer(modifier = Modifier.height(MaterialTheme.spacing.medium))
         }
 
         items(lessons) { lesson ->
+            val ribbonColor = if (lesson.mandatory) commonR.color.lesson_blue else commonR.color.lesson_orange
+
             RibbonLessonCard(
-                lessonName = lesson,
-                color = Color.Red,
-                onClick = { onClick(LessonsView.UIAction.LessonTap(lesson)) }
+                lessonName = lesson.name,
+                color = colorResource(ribbonColor),
+                onClick = { onAction(LessonsView.UIAction.LessonTap(lesson.name)) }
             )
         }
     }
@@ -116,12 +189,20 @@ private fun ShimmerLoading(paddingValues: PaddingValues) {
 private class LessonsScreenProvider : PreviewParameterProvider<LessonsView.State> {
 
     override val values = sequenceOf(
-        LessonsView.State.Loading,
+        LessonsView.State.Loading(semester = LoremIpsum(2).values.joinToString()),
         LessonsView.State.Content(
+            semester = LoremIpsum(2).values.joinToString(),
+            informativeText = LoremIpsum(5).values.joinToString(),
             lessons = persistentListOf(
-                "Εισαγωγή στην Οικονιμική Θεωρία",
-                "Μαθηματική Ανάλυση",
-                "Οργάνωση και Διοίκηση Επιχειρήσεων"
+                Lesson(
+                    name = "Εισαγωγή στην Οικονομική Θεωρία",
+                    description = LoremIpsum(5).values.joinToString(),
+                    hours = "5",
+                    mandatory = false,
+                    orientation = listOf(),
+                    semester = "A",
+                    ects = "5"
+                )
             )
         ),
         LessonsView.State.Error
@@ -134,7 +215,7 @@ private fun UserProfilePreview(@PreviewParameter(LessonsScreenProvider::class) s
     ElmepaAppTheme {
         LessonsScreen(
             state = state,
-            onClick = {}
+            onAction = {}
         )
     }
 }

--- a/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/lessons/LessonsView.kt
+++ b/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/lessons/LessonsView.kt
@@ -1,12 +1,21 @@
 package com.elmepa.syllabus.lessons
 
+import com.stathis.model.syllabus.Lesson
 import kotlinx.collections.immutable.ImmutableList
 
 internal sealed class LessonsView {
 
     sealed interface State {
-        data object Loading : State
-        data class Content(val lessons: ImmutableList<String>) : State
+        data object Init : State
+
+        data class Loading(val semester: String? = null) : State
+
+        data class Content(
+            val semester: String,
+            val informativeText: String,
+            val lessons: ImmutableList<Lesson>
+        ) : State
+
         data object Error : State
     }
 
@@ -15,6 +24,6 @@ internal sealed class LessonsView {
     }
 
     sealed interface Effect {
-        data class NavigateToLessonDetails(val lessonId: Int) : UIAction
+        data class NavigateToLessonDetails(val lessonName: String) : Effect
     }
 }

--- a/feature/syllabusv2/syllabus-ui/src/main/res/values/strings.xml
+++ b/feature/syllabusv2/syllabus-ui/src/main/res/values/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- Lessons Screen-->
+    <string name="modal_title">Επεξήγηση χρωμάτων</string>
+    <string name="modal_body">Τα μαθήματα που είναι σημειωμένα με μπλέ χρώμα στα αριστερά είναι μαθήματα υποχρεωτικά. Αντίστοιχα, μαθήματα τα οποία είναι σημειωμένα με πορτοκαλί χρώμα είναι μαθήματα επιλογής.</string>
+    <string name="modal_btn_txt">Εντάξει</string>
+
+</resources>


### PR DESCRIPTION
### 📝  Description

This PR migrates the lesson list to jetpack compose

---

### 🔄  Implementation

- Added new fragment
- Added new ViewModel
- Connected new fragment to app nav graph
---

### 🎬  Demo
| Light | Dark |
| --- | --- |
| <img width="347" alt="Screenshot 2025-04-19 at 10 10 45 PM" src="https://github.com/user-attachments/assets/2e6cd8b7-da66-4716-b8cc-18b99a86dad6" /> | <img width="347" alt="Screenshot 2025-04-19 at 10 10 39 PM" src="https://github.com/user-attachments/assets/c53740da-1820-4ee1-85d2-48b733b8428b" /> |
---

### 🧪  Testing
Open syllabus > Click on a semester > Tada! 🎆 
