### PR TITLE
Remove compose strong skipping

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/elmepa/convention/ext/AndroidCompose.kt
+++ b/build-logic/convention/src/main/kotlin/com/elmepa/convention/ext/AndroidCompose.kt
@@ -37,7 +37,6 @@ internal fun Project.configureAndroidCompose(
                 listOf(
                     buildComposeMetricsParameters(),
                     stabilityConfiguration(),
-                    strongSkippingConfiguration()
                 ).flatten()
             )
         }
@@ -74,9 +73,4 @@ private fun Project.buildComposeMetricsParameters(): List<String> {
 private fun Project.stabilityConfiguration() = listOf(
     "-P",
     "plugin:androidx.compose.compiler.plugins.kotlin:stabilityConfigurationPath=${project.rootDir.absolutePath}/compose_compiler_config.conf",
-)
-
-private fun Project.strongSkippingConfiguration() = listOf(
-    "-P",
-    "plugin:androidx.compose.compiler.plugins.kotlin:experimentalStrongSkipping=true",
 )


### PR DESCRIPTION
### 📝  Description

This PR removes the `StrongSkipping` feature flag from the `kotlinOptions.freeCompilerArgs` in build.gradle.

Starting with Jetpack Compose Compiler 1.5.x, StrongSkipping is enabled by default. Leaving this flag in the configuration is now redundant and triggers the following build-time warning:

_The feature plugin:androidx.compose.compiler.plugins.kotlin:featureFlag=StrongSkipping is enabled by default and specifying this option explicitly is not necessary._


---

### 🔄  Implementation
- Removed `StrongSkipping` from plugin 

---

### 🎬  Demo
N/A

---

### 🧪  Testing
N/A
