### PR TITLE
Update deprecated fallback to destructive migration in room db

### DIFF
--- a/core/database/src/main/java/com/stathis/database/di/DatabaseModule.kt
+++ b/core/database/src/main/java/com/stathis/database/di/DatabaseModule.kt
@@ -19,5 +19,5 @@ class DatabaseModule {
         application.applicationContext,
         NewsDatabase::class.java,
         "announcements_db"
-    ).fallbackToDestructiveMigration().build()
+    ).fallbackToDestructiveMigration(dropAllTables = true).build()
 }

--- a/feature/personnel/personnel-database/src/main/kotlin/com/elmepa/personnel/di/PersonnelDatabaseModule.kt
+++ b/feature/personnel/personnel-database/src/main/kotlin/com/elmepa/personnel/di/PersonnelDatabaseModule.kt
@@ -21,5 +21,5 @@ class PersonnelDatabaseModule {
         application.applicationContext,
         PersonnelDatabase::class.java,
         PERSONNEL_DB_NAME
-    ).fallbackToDestructiveMigration().build()
+    ).fallbackToDestructiveMigration(dropAllTables = true).build()
 }

--- a/feature/support/support-database/src/main/kotlin/com/elmepa/database/di/SupportDatabaseModule.kt
+++ b/feature/support/support-database/src/main/kotlin/com/elmepa/database/di/SupportDatabaseModule.kt
@@ -21,5 +21,5 @@ internal class SupportDatabaseModule {
         application.applicationContext,
         SupportLocalDatabase::class.java,
         SUPPORT_DB_NAME
-    ).fallbackToDestructiveMigration().build()
+    ).fallbackToDestructiveMigration(dropAllTables = true).build()
 }


### PR DESCRIPTION
### 📝  Description

`.fallbackToDestructiveMigration()` has been annotated as deprecated with message: _Replace by overloaded version with parameter to indicate if all tables should be dropped or not._ 

This PR uses the replacement (`.fallbackToDestructiveMigration(dropAllTables = boolean)`).

---

### 🔄  Implementation

- Update usages of `.fallbackToDestructiveMigration()`

---

### 🎬  Demo
N/A

---

### 🧪  Testing
- CI should be 🟢 
