### PR TITLE
Migrate programmes to compose

### DIFF
--- a/app/src/main/java/com/stathis/elmepaunivapp/MainActivity.kt
+++ b/app/src/main/java/com/stathis/elmepaunivapp/MainActivity.kt
@@ -43,6 +43,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
 
             val shouldHideToolbar = listOf(
                 R.id.aboutAppScreen,
+                R.id.nav_syllabus,
                 R.id.lessonsFragment,
                 R.id.lessonDetailsFragment
             ).contains(destination.id)

--- a/app/src/main/res/navigation/feature_nav.xml
+++ b/app/src/main/res/navigation/feature_nav.xml
@@ -43,14 +43,12 @@
     <fragment
         android:id="@+id/nav_personnel"
         android:name="com.elmepa.personnel.list.PersonnelFragment"
-        android:label="PersonnelFragment"
-        tools:layout="@layout/fragment_personnel" />
+        android:label="PersonnelFragment" />
 
     <fragment
         android:id="@+id/nav_syllabus"
-        android:name="com.stathis.syllabus.ui.syllabus.SyllabusFragment"
-        android:label="SyllabusFragment"
-        tools:layout="@layout/fragment_syllabus" />
+        android:name="com.elmepa.syllabus.programmes.ProgrammesFragment"
+        android:label="ProgrammesFragment" />
 
     <fragment
         android:id="@+id/lessonsFragment"

--- a/core/design-system/src/main/kotlin/com/elmepa/designsystem/components/topbar/TopBarWithTitle.kt
+++ b/core/design-system/src/main/kotlin/com/elmepa/designsystem/components/topbar/TopBarWithTitle.kt
@@ -1,0 +1,19 @@
+package com.elmepa.designsystem.components.topbar
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
+import com.elmepa.designsystem.theme.ElmepaAppTheme
+
+@Composable
+fun TopBarWithTitle(title: String) {
+    AppTopBar(title = title)
+}
+
+@PreviewLightDark
+@Composable
+private fun TopBarWithTitlePreview() {
+    ElmepaAppTheme {
+        TopBarWithTitle(title = LoremIpsum(3).values.joinToString())
+    }
+}

--- a/core/domain/src/main/java/com/stathis/domain/FetchSemestersUseCase.kt
+++ b/core/domain/src/main/java/com/stathis/domain/FetchSemestersUseCase.kt
@@ -1,21 +1,20 @@
 package com.stathis.domain
 
-import com.stathis.common.base.BaseUseCase
 import com.stathis.data.repository.SyllabusRepository
-import com.stathis.model.network.NetworkResult
 import com.stathis.model.syllabus.OrientationType
-import com.stathis.model.syllabus.Programme
 import com.stathis.model.syllabus.ProgrammeType
-import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flatMapConcat
+import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class FetchSemestersUseCase @Inject constructor(
     private val repo: SyllabusRepository
-) : BaseUseCase<Flow<NetworkResult<List<Programme>>>> {
+) {
 
-    override suspend fun invoke(vararg args: Any?): Flow<NetworkResult<List<Programme>>> {
+    operator fun invoke(vararg args: Any?) = flow {
         val selectedProgramme = args.getOrNull(0) as? ProgrammeType ?: ProgrammeType.UNDEFINED
         val selectedOrientation = args.getOrNull(1) as? OrientationType ?: OrientationType.DATA
-        return repo.fetchSemestersByProgrammeType(selectedProgramme, selectedOrientation)
-    }
+        val result = repo.fetchSemestersByProgrammeType(selectedProgramme, selectedOrientation)
+        emit(result)
+    }.flatMapConcat { it }
 }

--- a/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/const/Ext.kt
+++ b/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/const/Ext.kt
@@ -1,21 +1,10 @@
-package com.stathis.syllabus.util
+package com.elmepa.syllabus.const
 
 import com.stathis.model.syllabus.ProgrammeType
 
 /**
- * Helper fun to transform the tab position to a [ProgrammeType].
- */
-
-fun Int.toProgrammeType() = when (this) {
-    0 -> ProgrammeType.UNDERGRADUATE_MST
-    1 -> ProgrammeType.POSTGRADUATE_MST
-    else -> ProgrammeType.UNDEFINED
-}
-
-/**
  * Helper fun to transform a [ProgrammeType] to the tab position.
  */
-
 fun ProgrammeType?.toTabPosition() = when (this) {
     ProgrammeType.UNDERGRADUATE_MST -> 0
     ProgrammeType.POSTGRADUATE_MST -> 1

--- a/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/programmes/ProgrammesFragment.kt
+++ b/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/programmes/ProgrammesFragment.kt
@@ -1,0 +1,93 @@
+package com.elmepa.syllabus.programmes
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import com.elmepa.designsystem.theme.ElmepaAppTheme
+import com.elmepa.syllabus.const.ORIENTATION
+import com.elmepa.syllabus.const.PROGRAMME
+import com.elmepa.syllabus.const.SEMESTER
+import com.stathis.common.MainSharedViewModel
+import com.stathis.common.MainViewModel
+import com.stathis.model.navigation.NavigationAction
+import com.stathis.model.syllabus.OrientationType
+import com.stathis.model.syllabus.ProgrammeType
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+
+@AndroidEntryPoint
+class ProgrammesFragment : Fragment() {
+
+    private val viewModel by viewModels<ProgrammesViewModel>()
+    private val activityVM by activityViewModels<MainViewModel>()
+    private val sharedVM by activityViewModels<MainSharedViewModel>()
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                val state by viewModel.state.collectAsStateWithLifecycle()
+                ElmepaAppTheme {
+                    ProgrammesScreen(
+                        state = state,
+                        onAction = viewModel::onAction
+                    )
+                }
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        viewModel.fetchSemestersByProgramme(
+            programme = sharedVM.selectedProgrammeType,
+            orientation = sharedVM.selectedOrientation
+        )
+
+        viewModel.effect.flowWithLifecycle(lifecycle).onEach { effect ->
+            when (effect) {
+                is ProgrammesView.Effect.NavigateToLessonList -> goToLessonListScreen(
+                    programmeType = sharedVM.selectedProgrammeType,
+                    orientationType = sharedVM.selectedOrientation,
+                    semester = effect.semester
+                )
+
+                is ProgrammesView.Effect.ChangeSelectedTab -> {
+                    sharedVM.selectedProgrammeType = effect.toProgrammeType().also { programmeType ->
+                        viewModel.fetchSemestersByProgramme(
+                            programme = programmeType,
+                            orientation = sharedVM.selectedOrientation
+                        )
+                    }
+                }
+            }
+        }.launchIn(viewLifecycleOwner.lifecycleScope)
+    }
+
+    private fun goToLessonListScreen(programmeType: ProgrammeType, orientationType: OrientationType, semester: String) {
+        val args = Bundle().apply {
+            putSerializable(PROGRAMME, programmeType)
+            putSerializable(ORIENTATION, orientationType)
+            putString(SEMESTER, semester)
+        }
+
+        sharedVM.apply {
+            selectedProgrammeType = programmeType
+            selectedOrientation = orientationType
+        }
+
+        activityVM.navigateWithAction(NavigationAction.LESSONS, args)
+    }
+}

--- a/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/programmes/ProgrammesScreen.kt
+++ b/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/programmes/ProgrammesScreen.kt
@@ -4,10 +4,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -22,23 +20,35 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
+import com.elmepa.designsystem.components.topbar.TopBarWithTitle
 import com.elmepa.designsystem.theme.ElmepaAppTheme
 import com.elmepa.designsystem.theme.spacing
 import com.elmepa.syllabus.programmes.ProgrammesView.State
+import com.elmepa.syllabus.programmes.ProgrammesView.UIAction
 import com.elmepa.syllabus.programmes.components.ExpandableProgrammeCard
+import com.elmepa.syllabus.ui.R
+import com.stathis.model.syllabus.OrientationType
+import com.stathis.model.syllabus.Programme
+import com.stathis.model.syllabus.ProgrammeType
+import com.stathis.model.syllabus.Semester
 
 @Composable
-internal fun ProgrammesScreen(state: State) {
+internal fun ProgrammesScreen(state: State, onAction: (UIAction) -> Unit) {
     Scaffold(
         topBar = {
-            //
+            TopBarWithTitle(title = stringResource(com.stathis.common.R.string.syllabus))
         },
         content = { paddingValues ->
             when (state) {
                 is State.Loading -> Unit
                 is State.Content -> ProgrammesScreenContent(
-                    paddingValues = paddingValues
+                    paddingValues = paddingValues,
+                    selectedTabPosition = state.selectedTabPosition,
+                    programmes = state.programmes,
+                    onAction = onAction
                 )
 
                 is State.Error -> Unit
@@ -48,56 +58,72 @@ internal fun ProgrammesScreen(state: State) {
 }
 
 @Composable
-private fun ProgrammesScreenContent(paddingValues: PaddingValues) {
-    val tabTitles = listOf("Tab One", "Tab Two")
-    var selectedTabIndex by remember { mutableIntStateOf(0) }
-
+private fun ProgrammesScreenContent(
+    selectedTabPosition: Int? = null,
+    programmes: List<Programme>,
+    paddingValues: PaddingValues,
+    onAction: (UIAction) -> Unit
+) {
     Column(
         modifier = Modifier
             .fillMaxSize()
             .consumeWindowInsets(paddingValues)
+            .padding(top = paddingValues.calculateTopPadding())
             .background(MaterialTheme.colorScheme.background)
     ) {
-        TabRow(selectedTabIndex = selectedTabIndex) {
-            tabTitles.forEachIndexed { index, title ->
-                Tab(
-                    selected = selectedTabIndex == index,
-                    onClick = { selectedTabIndex = index },
-                    text = { Text(title) }
-                )
-            }
-        }
-
-        Spacer(modifier = Modifier.height(MaterialTheme.spacing.medium))
-
+        TabRow(
+            selectedTabPosition = selectedTabPosition,
+            onAction = onAction
+        )
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
                 .consumeWindowInsets(paddingValues)
                 .background(MaterialTheme.colorScheme.background)
                 .weight(1f),
-            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.small)
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.small),
+            contentPadding = PaddingValues(vertical = MaterialTheme.spacing.medium)
         ) {
-            val programmes = listOf("Programme One", "Programme Two", "Programme Three")
-            val semesters = listOf(
-                "Εξάμηνο Α'",
-                "Εξάμηνο Β'",
-                "Εξάμηνο Γ'",
-                "Εξάμηνο Δ'",
-                "Εξάμηνο Ε'",
-                "Εξάμηνο ΣΤ'",
-                "Εξάμηνο Ζ'",
-                "Εξάμηνο Η'",
-            )
 
             items(programmes) { programme ->
+                val semesters = programme.semesters.map { it.name }
+
                 ExpandableProgrammeCard(
                     modifier = Modifier.padding(horizontal = MaterialTheme.spacing.small),
-                    programme = programme,
+                    programme = programme.title,
+                    isExpanded = programme.isExpanded,
                     semesters = semesters,
-                    onSemesterClick = {}
+                    onSemesterClick = { semester -> onAction(UIAction.OnSemesterClick(semester)) }
                 )
             }
+        }
+    }
+}
+
+@Composable
+private fun TabRow(selectedTabPosition: Int? = null, onAction: (UIAction) -> Unit) {
+    val tabTitles = listOf(
+        stringResource(R.string.undergraduate_syllabus),
+        stringResource(R.string.postgraduate_syllabus)
+    )
+
+    var selectedTabIndex by remember { mutableIntStateOf(selectedTabPosition ?: 0) }
+
+    TabRow(selectedTabIndex = selectedTabIndex) {
+        tabTitles.forEachIndexed { index, title ->
+            Tab(
+                selected = selectedTabIndex == index,
+                onClick = {
+                    selectedTabIndex = index
+                    onAction(UIAction.OnTabSelection(selectedTabIndex))
+                },
+                text = {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
+            )
         }
     }
 }
@@ -106,6 +132,28 @@ private fun ProgrammesScreenContent(paddingValues: PaddingValues) {
 @Composable
 private fun ProgrammesScreenPreview() {
     ElmepaAppTheme {
-        ProgrammesScreen(state = State.Content)
+        val state = State.Content(
+            programmes = listOf(
+                Programme(
+                    title = LoremIpsum(3).values.joinToString(),
+                    type = ProgrammeType.UNDERGRADUATE_MST,
+                    orientationType = OrientationType.DATA,
+                    semesters = listOf(
+                        Semester(name = "Εξάμηνο Α'"),
+                        Semester(name = "Εξάμηνο Β'"),
+                        Semester(name = "Εξάμηνο Γ'"),
+                        Semester(name = "Εξάμηνο Δ'"),
+                        Semester(name = "Εξάμηνο Ε'"),
+                        Semester(name = "Εξάμηνο ΣΤ'"),
+                        Semester(name = "Εξάμηνο Η'"),
+                        Semester(name = "Εξάμηνο Ζ'")
+                    )
+                )
+            )
+        )
+        ProgrammesScreen(
+            state = state,
+            onAction = {}
+        )
     }
 }

--- a/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/programmes/ProgrammesView.kt
+++ b/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/programmes/ProgrammesView.kt
@@ -1,19 +1,41 @@
 package com.elmepa.syllabus.programmes
 
+import com.stathis.model.syllabus.Programme
+import com.stathis.model.syllabus.ProgrammeType
+import kotlinx.collections.immutable.persistentListOf
+
 internal class ProgrammesView {
 
     sealed interface State {
-
         data object Loading : State
-        data object Content : State
+
+        data class Content(
+            val selectedTabPosition: Int = 0,
+            val programmes: List<Programme> = persistentListOf()
+        ) : State
+
         data object Error : State
     }
 
     sealed interface UIAction {
+        data class OnTabSelection(val tabIndex: Int) : UIAction
 
+        data class OnSemesterClick(val semester: String) : UIAction
     }
 
     sealed interface Effect {
+        data class ChangeSelectedTab(val tabIndex: Int) : Effect {
 
+            /**
+             * Helper fun to transform the tab position to a [ProgrammeType].
+             */
+            fun toProgrammeType() = when (tabIndex) {
+                0 -> ProgrammeType.UNDERGRADUATE_MST
+                1 -> ProgrammeType.POSTGRADUATE_MST
+                else -> ProgrammeType.UNDEFINED
+            }
+        }
+
+        data class NavigateToLessonList(val semester: String) : Effect
     }
 }

--- a/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/programmes/ProgrammesViewModel.kt
+++ b/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/programmes/ProgrammesViewModel.kt
@@ -1,0 +1,87 @@
+package com.elmepa.syllabus.programmes
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.elmepa.syllabus.const.toTabPosition
+import com.elmepa.syllabus.programmes.ProgrammesView.Effect
+import com.elmepa.syllabus.programmes.ProgrammesView.Effect.ChangeSelectedTab
+import com.elmepa.syllabus.programmes.ProgrammesView.Effect.NavigateToLessonList
+import com.elmepa.syllabus.programmes.ProgrammesView.State
+import com.elmepa.syllabus.programmes.ProgrammesView.UIAction
+import com.stathis.common.di.IoDispatcher
+import com.stathis.domain.FetchSemestersUseCase
+import com.stathis.model.network.NetworkResult
+import com.stathis.model.syllabus.OrientationType
+import com.stathis.model.syllabus.Programme
+import com.stathis.model.syllabus.ProgrammeType
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+internal class ProgrammesViewModel @Inject constructor(
+    @IoDispatcher private val dispatcher: CoroutineDispatcher,
+    private val useCase: FetchSemestersUseCase
+) : ViewModel() {
+
+    private val _state = MutableStateFlow<State>(State.Loading)
+    val state = _state.asStateFlow()
+
+    private val _effect = MutableSharedFlow<Effect>()
+    val effect = _effect.asSharedFlow()
+
+    fun fetchSemestersByProgramme(programme: ProgrammeType?, orientation: OrientationType? = null) {
+        useCase.invoke(programme, orientation)
+            .onStart {
+                _state.update { State.Loading }
+            }
+            .onEach { result ->
+                _state.update { result.toUiState(programme) }
+            }
+            .flowOn(dispatcher)
+            .launchIn(viewModelScope)
+    }
+
+    fun onAction(action: UIAction) {
+        viewModelScope.launch(dispatcher) {
+            val effect = when (action) {
+                is UIAction.OnSemesterClick -> NavigateToLessonList(action.semester)
+
+                is UIAction.OnTabSelection -> {
+                    _state.update {
+                        (it as State.Content).copy(selectedTabPosition = action.tabIndex)
+                    }
+                    ChangeSelectedTab(action.tabIndex)
+                }
+            }
+
+            _effect.emit(effect)
+        }
+    }
+
+    private fun NetworkResult<List<Programme>>.toUiState(programme: ProgrammeType?) = when (this) {
+        is NetworkResult.Loading -> State.Loading
+
+        is NetworkResult.Success -> {
+            val selectedTabPosition = programme.toTabPosition()
+            State.Content(
+                selectedTabPosition = selectedTabPosition,
+                programmes = data?.mapIndexed { index, elem ->
+                    elem.copy(isExpanded = index == selectedTabPosition)
+                }?.toList().orEmpty()
+            )
+        }
+
+        is NetworkResult.Failure -> State.Error
+    }
+}

--- a/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/programmes/components/ExpandableProgrammeCard.kt
+++ b/feature/syllabusv2/syllabus-ui/src/main/kotlin/com/elmepa/syllabus/programmes/components/ExpandableProgrammeCard.kt
@@ -45,10 +45,11 @@ import com.elmepa.designsystem.theme.spacing
 internal fun ExpandableProgrammeCard(
     modifier: Modifier = Modifier,
     programme: String,
+    isExpanded: Boolean,
     semesters: List<String>,
     onSemesterClick: (String) -> Unit
 ) {
-    var isExpanded by rememberSaveable { mutableStateOf(false) }
+    var isExpanded by rememberSaveable { mutableStateOf(isExpanded) }
     val rotationAngle by animateFloatAsState(
         targetValue = if (isExpanded) 90f else 0f,
         label = "Rotation"
@@ -169,6 +170,7 @@ private fun ExpandableProgrammeCardPreview() {
         ExpandableProgrammeCard(
             programme = "Επιστήμη των Δεδομένων & Τεχνολογίες Πληροφορικής",
             semesters = semesters,
+            isExpanded = true,
             onSemesterClick = {}
         )
     }

--- a/feature/syllabusv2/syllabus-ui/src/main/res/values/strings.xml
+++ b/feature/syllabusv2/syllabus-ui/src/main/res/values/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <!-- Programmes Screen -->
+    <string name="undergraduate_syllabus">Προπτυχιακό Π.Σ</string>
+    <string name="postgraduate_syllabus">Μεταπτυχιακό Π.Σ</string>
+
     <!-- Lessons Screen-->
     <string name="modal_title">Επεξήγηση χρωμάτων</string>
     <string name="modal_body">Τα μαθήματα που είναι σημειωμένα με μπλέ χρώμα στα αριστερά είναι μαθήματα υποχρεωτικά. Αντίστοιχα, μαθήματα τα οποία είναι σημειωμένα με πορτοκαλί χρώμα είναι μαθήματα επιλογής.</string>


### PR DESCRIPTION
### 📝  Description

This PR migrates the programmes (syllabus intro) screen to `Jetpack Compose`.

---

### 🔄  Implementation

- Added new Fragment
- Added new ViewModel
- Modified the screen's state
- Hid the toolbar for that screen in `MainActivity`
- Transfered any strings to the new module

---

### 🎬  Demo
N/A

---

### 🧪  Testing
- Open the app > tap on syllabus > Tada!
