### PR TITLE
[Chore] Migrate kotlinOptions to compilerOptions in Gradle build

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -12,8 +13,8 @@ java {
 }
 
 tasks.withType<KotlinCompile>().configureEach {
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_21.toString()
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_21)
     }
 }
 

--- a/build-logic/convention/src/main/kotlin/com/elmepa/convention/ext/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/com/elmepa/convention/ext/KotlinAndroid.kt
@@ -7,6 +7,7 @@ import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.provideDelegate
 import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 internal fun Project.configureKotlinAndroid(
@@ -39,12 +40,11 @@ internal fun Project.configureKotlinJvm() {
 
 private fun Project.configureKotlin() {
     tasks.withType<KotlinCompile>().configureEach {
-        kotlinOptions {
-            jvmTarget = JavaVersion.VERSION_21.toString()
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_21)
             val warningsAsErrors: String? by project
-            allWarningsAsErrors = warningsAsErrors.toBoolean()
-            freeCompilerArgs = freeCompilerArgs + listOf(
-                // Enable experimental coroutines APIs, including Flow
+            allWarningsAsErrors.set(warningsAsErrors.toBoolean())
+            freeCompilerArgs.addAll(
                 "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
             )
         }


### PR DESCRIPTION
### 📝  Description

This PR updates the Gradle Kotlin compilation configuration by replacing the deprecated` kotlinOptions {}` block with the new `compilerOptions {} `API for all `KotlinCompile` tasks.

Fixes #ISSUE_NUMBER

---

### 🔄  Implementation

- Replaced usage of kotlinOptions {} with compilerOptions {}.
- Updated assignments to use Property<T> API (set(), addAll()) as per Gradle's best practices.
- Migrated jvmTarget to use the strongly typed JvmTarget enum (JvmTarget.JVM_21).
- Ensured experimental compiler arguments are added via freeCompilerArgs.addAll.

---

### 🎬  Demo
- N/A

---

### 🧪  Testing
- N/A

