### PR TITLE
Revert datastore version update back to v.1.1.4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,7 +55,7 @@ room = "2.7.1"
 #Circle ImageView
 circleImgView = "3.1.0"
 #DataStore local storage
-dataStore = "1.1.5"
+dataStore = "1.1.4"
 #Paging3
 paging = "3.3.6"
 #Gson


### PR DESCRIPTION
### 📝  Description

This PR reverts the datastore version back to `v.1.1.4` until we investigate the reason that `v.1.1.5` fails on GHA CI

---

### 🔄  Implementation
- Revert datastore version to `v.1.1.4`

---

### 🎬  Demo
N/A

---

### 🧪  Testing
N/A
