### PR TITLE
Introduce new newsv2 module

### DIFF
--- a/feature/newsv2/news-data/build.gradle.kts
+++ b/feature/newsv2/news-data/build.gradle.kts
@@ -1,0 +1,25 @@
+plugins {
+    alias(libs.plugins.elmepa.android.library)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.elmepa.android.hilt)
+    alias(libs.plugins.elmepa.android.room)
+}
+
+android {
+    namespace = "com.elmepa.news.data"
+}
+
+dependencies {
+    implementation(project(":core:data"))
+    implementation(project(":core:common"))
+    implementation(project(":core:model"))
+    implementation(project(":core:domain"))
+    implementation(project(":core:datastore"))
+
+    implementation(project(":feature:newsv2:news-database"))
+    implementation(project(":feature:newsv2:news-domain"))
+
+    implementation(libs.firebase.firestore)
+
+    implementation(libs.jsoup)
+}

--- a/feature/newsv2/news-database/build.gradle.kts
+++ b/feature/newsv2/news-database/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    alias(libs.plugins.elmepa.android.library)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.elmepa.android.hilt)
+    alias(libs.plugins.elmepa.android.room)
+}
+
+android {
+    namespace = "com.elmepa.news.database"
+}
+
+dependencies {
+    implementation(project(":core:model"))
+    implementation(project(":feature:newsv2:news-domain"))
+}

--- a/feature/newsv2/news-domain/build.gradle.kts
+++ b/feature/newsv2/news-domain/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    alias(libs.plugins.elmepa.android.library)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.elmepa.android.hilt)
+}
+
+android {
+    namespace = "com.elmepa.news.domain"
+}
+
+dependencies {
+    implementation(project(":core:common"))
+    implementation(project(":core:model"))
+    implementation(project(":core:domain"))
+}

--- a/feature/newsv2/news-ui/build.gradle.kts
+++ b/feature/newsv2/news-ui/build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+    alias(libs.plugins.elmepa.android.feature)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.elmepa.android.hilt)
+    alias(libs.plugins.elmepa.android.library)
+    alias(libs.plugins.elmepa.android.compose)
+    alias(libs.plugins.compose.compiler)
+}
+
+android {
+    namespace = "com.elmepa.news.ui"
+}
+
+dependencies {
+    implementation(project(":core:model"))
+    implementation(project(":core:common"))
+    implementation(project(":core:design-system"))
+
+    implementation(project(":core:domain"))
+    implementation(project(":feature:newsv2:news-domain"))
+
+    implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.appcompat)
+    implementation(libs.fragment.navigation)
+
+    implementation(libs.viewModelLifecycle)
+    implementation(libs.lifecycle.common)
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -50,6 +50,11 @@ include(":feature:personnel:personnel-ui")
 //Syllabus
 include(":feature:syllabus:syllabus-ui")
 
+// News
+include(":feature:newsv2:news-data")
+include(":feature:newsv2:news-database")
+include(":feature:newsv2:news-domain")
+include(":feature:newsv2:news-ui")
 
 include(":feature:news")
 include(":feature:web")


### PR DESCRIPTION
### 📝  Description

This PR introduces the newsv2 module skeleton

---

### 🔄  Implementation

- Added the following modules under the newly introduced `newsv2` module
   - news-data
   - news-database
   - news-domain
   - news-ui
   
---

### 🎬  Demo
N/A

---

### 🧪  Testing
Nothing to test yet
