### PR TITLE
Create news card composable

### DIFF
--- a/feature/newsv2/news-ui/build.gradle.kts
+++ b/feature/newsv2/news-ui/build.gradle.kts
@@ -23,6 +23,9 @@ dependencies {
     implementation(libs.androidx.appcompat)
     implementation(libs.fragment.navigation)
 
+    implementation(libs.coil)
+    implementation(libs.coil.okhttp)
+
     implementation(libs.viewModelLifecycle)
     implementation(libs.lifecycle.common)
 }

--- a/feature/newsv2/news-ui/src/main/kotlin/com/elmepa/news/announcements/components/AnnouncementCard.kt
+++ b/feature/newsv2/news-ui/src/main/kotlin/com/elmepa/news/announcements/components/AnnouncementCard.kt
@@ -1,0 +1,96 @@
+package com.elmepa.news.announcements.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import com.elmepa.designsystem.theme.ElmepaAppTheme
+import com.elmepa.designsystem.theme.Petrol
+import com.elmepa.designsystem.theme.TextGrey
+import com.elmepa.designsystem.theme.spacing
+import com.stathis.common.R as common
+
+@Composable
+internal fun AnnouncementCard(
+    modifier: Modifier = Modifier,
+    imageUrl: String,
+    datePublished: String,
+    title: String,
+    subtitle: String,
+    onClick: () -> Unit
+) {
+    Card(
+        modifier = modifier
+            .clickable { onClick() },
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+    ) {
+        Row(modifier = Modifier.padding(all = MaterialTheme.spacing.medium)) {
+            AsyncImage(
+                modifier = Modifier
+                    .height(200.dp)
+                    .width(120.dp),
+                model = imageUrl,
+                contentScale = ContentScale.Crop,
+                placeholder = painterResource(common.drawable.placeholder),
+                error = painterResource(common.drawable.placeholder),
+                contentDescription = title
+            )
+
+            Column(modifier = Modifier.padding(all = MaterialTheme.spacing.medium)) {
+                Text(
+                    text = datePublished,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = Petrol
+                )
+                Spacer(modifier = Modifier.height(MaterialTheme.spacing.medium))
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 3,
+                )
+                Spacer(modifier = Modifier.height(MaterialTheme.spacing.small))
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = TextGrey,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun AnnouncementCardPreview() {
+    ElmepaAppTheme {
+        AnnouncementCard(
+            imageUrl = "https://mst.hmu.gr/wp-content/uploads/2021/04/mst-enimerosi.jpg",
+            datePublished = "Απρ 30, 2025",
+            title = LoremIpsum(4).values.joinToString(),
+            subtitle = LoremIpsum(15).values.joinToString(),
+            onClick = {}
+        )
+    }
+}


### PR DESCRIPTION
### 📝  Description

This PR adds the news card composable in the app's codebase

---

### 🔄  Implementation

- Create the news card in compose

---

### 🎬  Demo

<img width="396" alt="Screenshot 2025-05-01 at 4 51 46 PM" src="https://github.com/user-attachments/assets/4bb042e9-b58f-4dbe-a218-5ca25ae2ba53" />

---

### 🧪  Testing
N/A
