### PR TITLE
Migrate events screen to compose

### DIFF
--- a/app/src/main/java/com/stathis/elmepaunivapp/MainActivity.kt
+++ b/app/src/main/java/com/stathis/elmepaunivapp/MainActivity.kt
@@ -52,6 +52,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
                 R.id.faqFragment,
                 R.id.contactFragment,
                 R.id.announcementsFragment,
+                R.id.eventsFragment,
             ).contains(destination.id)
 
             binding.toolbar.visibility = if (shouldHideToolbar) {

--- a/app/src/main/res/navigation/feature_nav.xml
+++ b/app/src/main/res/navigation/feature_nav.xml
@@ -17,9 +17,8 @@
 
     <fragment
         android:id="@+id/eventsFragment"
-        android:name="com.stathis.news.events.EventsFragment"
-        android:label="EventsFragment"
-        tools:layout="@layout/fragment_events" />
+        android:name="com.elmepa.news.events.EventsFragment"
+        android:label="EventsFragment" />
 
     <fragment
         android:id="@+id/postDetailsFragment"

--- a/core/domain/src/main/java/com/stathis/domain/news/FetchEventsUseCase.kt
+++ b/core/domain/src/main/java/com/stathis/domain/news/FetchEventsUseCase.kt
@@ -7,5 +7,5 @@ class FetchEventsUseCase @Inject constructor(
     private val repo: NewsRepository
 ) {
 
-    fun invoke() = repo.fetchEventsFromRemote()
+    operator fun invoke() = repo.fetchEventsFromRemote()
 }

--- a/feature/newsv2/news-ui/src/main/kotlin/com/elmepa/news/events/EventsFragment.kt
+++ b/feature/newsv2/news-ui/src/main/kotlin/com/elmepa/news/events/EventsFragment.kt
@@ -1,0 +1,70 @@
+package com.elmepa.news.events
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
+import androidx.paging.compose.collectAsLazyPagingItems
+import com.elmepa.designsystem.theme.ElmepaAppTheme
+import com.elmepa.news.events.EventsView.Effect
+import com.stathis.common.MainViewModel
+import com.stathis.common.util.IMAGE
+import com.stathis.common.util.PUB_DATE
+import com.stathis.common.util.TITLE
+import com.stathis.common.util.URL
+import com.stathis.model.navigation.NavigationAction
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+
+@AndroidEntryPoint
+class EventsFragment : Fragment() {
+
+    private val viewModel by viewModels<EventsViewModel>()
+    private val activityVM by activityViewModels<MainViewModel>()
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                val events = viewModel.events.collectAsLazyPagingItems()
+                ElmepaAppTheme {
+                    EventsScreen(
+                        events = events,
+                        onAction = viewModel::onAction
+                    )
+                }
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        viewModel.effect.flowWithLifecycle(lifecycle).onEach { effect ->
+            when (effect) {
+                is Effect.NavigateToDetails -> {
+                    val args = Bundle().apply {
+                        putString(TITLE, effect.event.name)
+                        putString(IMAGE, effect.event.imageResource)
+                        putString(URL, effect.event.url)
+                        putString(PUB_DATE, effect.event.pubDate)
+                    }
+                    activityVM.navigateWithAction(NavigationAction.POST_DETAILS, args)
+                }
+
+                is Effect.Back -> {
+                    findNavController().popBackStack()
+                }
+            }
+        }.launchIn(lifecycleScope)
+    }
+}

--- a/feature/newsv2/news-ui/src/main/kotlin/com/elmepa/news/events/EventsScreen.kt
+++ b/feature/newsv2/news-ui/src/main/kotlin/com/elmepa/news/events/EventsScreen.kt
@@ -1,0 +1,106 @@
+package com.elmepa.news.events
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import androidx.paging.LoadState
+import androidx.paging.compose.LazyPagingItems
+import com.elmepa.designsystem.components.shimmer.ShimmerEffect
+import com.elmepa.designsystem.components.topbar.TopBarWithTitleAndBackAction
+import com.elmepa.designsystem.theme.ElmepaAppTheme
+import com.elmepa.designsystem.theme.spacing
+import com.elmepa.news.announcements.components.AnnouncementCard
+import com.elmepa.news.events.EventsView.UIAction
+import com.stathis.common.R
+import com.stathis.model.announcements.Event
+
+@Composable
+internal fun EventsScreen(
+    events: LazyPagingItems<Event>,
+    onAction: (UIAction) -> Unit
+) {
+    Scaffold(
+        topBar = {
+            TopBarWithTitleAndBackAction(
+                title = stringResource(R.string.events),
+                onBackActionClick = { onAction(UIAction.Back) }
+            )
+        },
+        content = { paddingValues ->
+            EventsContent(paddingValues, events, onAction)
+        }
+    )
+}
+
+@Composable
+private fun EventsContent(
+    paddingValues: PaddingValues,
+    events: LazyPagingItems<Event>,
+    onAction: (UIAction) -> Unit
+) {
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(top = paddingValues.calculateTopPadding()),
+        contentPadding = PaddingValues(MaterialTheme.spacing.small),
+        verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.small)
+    ) {
+        item {
+            when (events.loadState.append) {
+                is LoadState.Loading -> ShimmerLoading()
+                is LoadState.Error -> Unit
+                else -> Unit
+            }
+        }
+
+        items(events.itemCount) { index ->
+            events[index]?.let { event ->
+                AnnouncementCard(
+                    imageUrl = event.imageResource,
+                    datePublished = event.pubDate,
+                    title = event.name,
+                    subtitle = event.description,
+                    onClick = {
+                        onAction(UIAction.OnEventTap(event))
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ShimmerLoading() {
+    repeat(10) {
+        ShimmerEffect(
+            modifier = Modifier
+                .height(200.dp)
+                .clip(RoundedCornerShape(8))
+                .fillMaxWidth()
+        )
+
+        Spacer(Modifier.height(MaterialTheme.spacing.small))
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun EventsScreenPreview() {
+    ElmepaAppTheme {
+
+    }
+}

--- a/feature/newsv2/news-ui/src/main/kotlin/com/elmepa/news/events/EventsView.kt
+++ b/feature/newsv2/news-ui/src/main/kotlin/com/elmepa/news/events/EventsView.kt
@@ -1,0 +1,16 @@
+package com.elmepa.news.events
+
+import com.stathis.model.announcements.Event
+
+internal sealed class EventsView {
+
+    sealed interface UIAction {
+        data class OnEventTap(val event: Event) : UIAction
+        data object Back : UIAction
+    }
+
+    sealed interface Effect {
+        data class NavigateToDetails(val event: Event) : Effect
+        data object Back : Effect
+    }
+}

--- a/feature/newsv2/news-ui/src/main/kotlin/com/elmepa/news/events/EventsViewModel.kt
+++ b/feature/newsv2/news-ui/src/main/kotlin/com/elmepa/news/events/EventsViewModel.kt
@@ -1,0 +1,45 @@
+package com.elmepa.news.events
+
+import android.app.Application
+import androidx.lifecycle.viewModelScope
+import androidx.paging.cachedIn
+import com.elmepa.news.events.EventsView.Effect
+import com.elmepa.news.events.EventsView.UIAction
+import com.stathis.common.base.BaseViewModel
+import com.stathis.common.di.IoDispatcher
+import com.stathis.domain.news.FetchEventsUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+internal class EventsViewModel @Inject constructor(
+    app: Application,
+    @IoDispatcher private val dispatcher: CoroutineDispatcher,
+    eventsUseCase: FetchEventsUseCase
+) : BaseViewModel(app) {
+
+    val events = eventsUseCase()
+        .flow
+        .flowOn(dispatcher)
+        .cachedIn(viewModelScope)
+
+    private val _effect = MutableSharedFlow<Effect>()
+    val effect: SharedFlow<Effect> = _effect.asSharedFlow()
+
+    fun onAction(action: UIAction) {
+        viewModelScope.launch(Dispatchers.Default) {
+            val effect = when (action) {
+                is UIAction.OnEventTap -> Effect.NavigateToDetails(action.event)
+                is UIAction.Back -> Effect.Back
+            }
+            _effect.emit(effect)
+        }
+    }
+}

--- a/feature/newsv2/news-ui/src/main/res/values/strings.xml
+++ b/feature/newsv2/news-ui/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="announcements">Ανακοινώσεις</string>
+    <string name="events">Γεγονότα &amp; Εκδηλώσεις</string>
 </resources>


### PR DESCRIPTION
### 📝  Description

This PR migrates the events screen to Jetpack compose

---

### 🔄  Implementation

- Migrated the events screen to Jetpack compose

---

### 🎬  Demo
N/A

---

### 🧪  Testing
- Home screen > Open events screen
