### PR TITLE
Fix share functionality on post details

### DIFF
--- a/feature/news/news-ui/src/main/kotlin/com/elmepa/news/details/PostDetailsViewModel.kt
+++ b/feature/news/news-ui/src/main/kotlin/com/elmepa/news/details/PostDetailsViewModel.kt
@@ -58,13 +58,16 @@ internal class PostDetailsViewModel @Inject constructor(
     fun onAction(action: UIAction) {
         val effect = when (action) {
             is UIAction.Back -> Effect.GoBack
-            is UIAction.Share -> with(state.value as State.Content) {
-                Effect.SharePost(title, openUrl)
+
+            is UIAction.Share -> (state.value as? State.Content)?.let {
+                Effect.SharePost(it.title, it.openUrl)
             }
         }
 
-        viewModelScope.launch(dispatcher) {
-            _effect.emit(effect)
+        effect?.let {
+            viewModelScope.launch(dispatcher) {
+                _effect.emit(effect)
+            }
         }
     }
 


### PR DESCRIPTION
### 📝  Description

This PR addresses the following crashlytics issue

> Fatal Exception: java.lang.ClassCastException
com.elmepa.news.details.PostDetailsView$State$Loading cannot be cast to com.elmepa.news.details.PostDetailsView$State$Content

---

### 🔄  Implementation
- Added check for sharing on different states

---

### 🎬  Demo
N/A

---

### 🧪  Testing
- Nothing need to be tested
