### PR TITLE
Migrate academic schedule to jetpack compose

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -100,6 +100,8 @@ dependencies {
 
     implementation(project(":feature:syllabus:syllabus-ui"))
 
+    implementation(project(":feature:studentsv2:students-ui"))
+
     implementation(project(":feature:students"))
     implementation(project(":feature:department"))
     implementation(project(":feature:web"))

--- a/app/src/main/java/com/stathis/elmepaunivapp/MainActivity.kt
+++ b/app/src/main/java/com/stathis/elmepaunivapp/MainActivity.kt
@@ -54,6 +54,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
                 R.id.announcementsFragment,
                 R.id.eventsFragment,
                 R.id.postDetailsFragment,
+                R.id.academicScheduleFragment
             ).contains(destination.id)
 
             binding.toolbar.visibility = if (shouldHideToolbar) {

--- a/app/src/main/res/navigation/feature_nav.xml
+++ b/app/src/main/res/navigation/feature_nav.xml
@@ -94,7 +94,7 @@
         android:label="ApplicationFormsFragment" />
     <fragment
         android:id="@+id/academicScheduleFragment"
-        android:name="com.stathis.students.acadschedule.AcademicScheduleFragment"
+        android:name="com.elmepa.students.ui.acadschedule.AcademicScheduleFragment"
         android:label="AcademicScheduleFragment"
         tools:layout="@layout/fragment_academic_schedule" />
 

--- a/core/data/src/main/java/com/stathis/data/repository/StudentsRepository.kt
+++ b/core/data/src/main/java/com/stathis/data/repository/StudentsRepository.kt
@@ -8,5 +8,5 @@ interface StudentsRepository {
 
     suspend fun fetchStudentScreenData(): Flow<NetworkResult<List<UiModel>>>
 
-    suspend fun fetchAcademicSchedule(): Flow<NetworkResult<List<UiModel>>>
+    fun fetchAcademicSchedule(): Flow<NetworkResult<List<UiModel>>>
 }

--- a/core/data/src/main/java/com/stathis/data/repository/StudentsRepositoryImpl.kt
+++ b/core/data/src/main/java/com/stathis/data/repository/StudentsRepositoryImpl.kt
@@ -47,7 +47,7 @@ class StudentsRepositoryImpl @Inject constructor(
         emit(NetworkResult.Success(result))
     }
 
-    override suspend fun fetchAcademicSchedule(): Flow<NetworkResult<List<UiModel>>> = flow {
+    override fun fetchAcademicSchedule(): Flow<NetworkResult<List<UiModel>>> = flow {
         try {
             emit(NetworkResult.Loading(ShimmerGenerator.list))
             val dtoModels = Jsoup.connect(ACADEMIC_SCHEDULE_URL).get()

--- a/core/domain/src/main/java/com/stathis/domain/students/FetchAcademicScheduleUseCase.kt
+++ b/core/domain/src/main/java/com/stathis/domain/students/FetchAcademicScheduleUseCase.kt
@@ -1,15 +1,11 @@
 package com.stathis.domain.students
 
-import com.stathis.common.base.BaseUseCase
 import com.stathis.data.repository.StudentsRepository
-import com.stathis.model.UiModel
-import com.stathis.model.network.NetworkResult
-import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class FetchAcademicScheduleUseCase @Inject constructor(
     private val repository: StudentsRepository
-) : BaseUseCase<Flow<NetworkResult<List<UiModel>>>> {
+) {
 
-    override suspend fun invoke(vararg args: Any?) = repository.fetchAcademicSchedule()
+    operator fun invoke() = repository.fetchAcademicSchedule()
 }

--- a/feature/studentsv2/students-ui/src/main/kotlin/com/elmepa/students/ui/acadschedule/AcademicScheduleFragment.kt
+++ b/feature/studentsv2/students-ui/src/main/kotlin/com/elmepa/students/ui/acadschedule/AcademicScheduleFragment.kt
@@ -1,0 +1,52 @@
+package com.elmepa.students.ui.acadschedule
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
+import com.elmepa.designsystem.theme.ElmepaAppTheme
+import com.elmepa.students.ui.acadschedule.AcademicScheduleView.Effect
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+
+@AndroidEntryPoint
+class AcademicScheduleFragment : Fragment() {
+
+    private val viewModel by viewModels<AcademicScheduleViewModel>()
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                val state by viewModel.state.collectAsStateWithLifecycle()
+                ElmepaAppTheme {
+                    AcademicScheduleScreen(
+                        state = state,
+                        onAction = viewModel::onAction
+                    )
+                }
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        viewModel.effect.flowWithLifecycle(lifecycle)
+            .onEach { effect ->
+                when (effect) {
+                    is Effect.GoBack -> findNavController().popBackStack()
+                }
+            }.launchIn(lifecycleScope)
+    }
+}

--- a/feature/studentsv2/students-ui/src/main/kotlin/com/elmepa/students/ui/acadschedule/AcademicScheduleScreen.kt
+++ b/feature/studentsv2/students-ui/src/main/kotlin/com/elmepa/students/ui/acadschedule/AcademicScheduleScreen.kt
@@ -1,0 +1,111 @@
+package com.elmepa.students.ui.acadschedule
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.elmepa.designsystem.components.cards.CardWithTitleAndSubtitle
+import com.elmepa.designsystem.components.shimmer.ShimmerEffect
+import com.elmepa.designsystem.components.topbar.TopBarWithTitleAndBackAction
+import com.elmepa.designsystem.theme.spacing
+import com.elmepa.students.ui.acadschedule.AcademicScheduleView.State
+import com.elmepa.students.ui.acadschedule.AcademicScheduleView.UIAction
+import com.stathis.common.R
+import com.stathis.model.UiModel
+import com.stathis.model.students.AcademicScheduleEntry
+import com.stathis.model.students.AcademicScheduleTitle
+
+@Composable
+internal fun AcademicScheduleScreen(state: State, onAction: (UIAction) -> Unit) {
+    Scaffold(
+        topBar = {
+            TopBarWithTitleAndBackAction(
+                title = stringResource(R.string.acad_schedule_title),
+                onBackActionClick = { onAction(UIAction.OnBackArrowTap) }
+            )
+        },
+        content = { paddingValues ->
+            when (state) {
+                is State.Loading -> AcademicScheduleLoading(
+                    modifier = Modifier.padding(top = paddingValues.calculateTopPadding())
+                )
+
+                is State.Content -> AcademicScheduleContent(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(top = paddingValues.calculateTopPadding())
+                        .background(MaterialTheme.colorScheme.background),
+                    data = state.items
+                )
+
+                is State.Error -> Unit
+            }
+        }
+    )
+}
+
+@Composable
+private fun AcademicScheduleLoading(modifier: Modifier) {
+    LazyColumn(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.small),
+        contentPadding = PaddingValues(MaterialTheme.spacing.small)
+    ) {
+        items(count = 10) {
+            ShimmerEffect(
+                modifier = Modifier
+                    .height(100.dp)
+                    .fillMaxWidth()
+            )
+        }
+    }
+}
+
+@Composable
+private fun AcademicScheduleContent(
+    modifier: Modifier,
+    data: List<UiModel>
+) {
+    LazyColumn(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.small),
+        contentPadding = PaddingValues(MaterialTheme.spacing.small)
+    ) {
+        items(data) { item ->
+            when (item) {
+                is AcademicScheduleTitle -> {
+                    Text(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = MaterialTheme.spacing.medium),
+                        text = item.title,
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        textAlign = TextAlign.Center
+                    )
+                }
+
+                is AcademicScheduleEntry -> {
+                    CardWithTitleAndSubtitle(
+                        title = item.title,
+                        subtitle = item.date,
+                        onAction = {}
+                    )
+                }
+            }
+        }
+    }
+}

--- a/feature/studentsv2/students-ui/src/main/kotlin/com/elmepa/students/ui/acadschedule/AcademicScheduleView.kt
+++ b/feature/studentsv2/students-ui/src/main/kotlin/com/elmepa/students/ui/acadschedule/AcademicScheduleView.kt
@@ -1,0 +1,20 @@
+package com.elmepa.students.ui.acadschedule
+
+import com.stathis.model.UiModel
+
+internal sealed class AcademicScheduleView {
+
+    sealed interface State {
+        data object Loading : State
+        data class Content(val items: List<UiModel>) : State
+        data object Error : State
+    }
+
+    sealed interface UIAction {
+        data object OnBackArrowTap : UIAction
+    }
+
+    sealed interface Effect {
+        data object GoBack : Effect
+    }
+}

--- a/feature/studentsv2/students-ui/src/main/kotlin/com/elmepa/students/ui/acadschedule/AcademicScheduleViewModel.kt
+++ b/feature/studentsv2/students-ui/src/main/kotlin/com/elmepa/students/ui/acadschedule/AcademicScheduleViewModel.kt
@@ -1,0 +1,56 @@
+package com.elmepa.students.ui.acadschedule
+
+import android.app.Application
+import androidx.lifecycle.viewModelScope
+import com.elmepa.students.ui.acadschedule.AcademicScheduleView.Effect
+import com.elmepa.students.ui.acadschedule.AcademicScheduleView.State
+import com.elmepa.students.ui.acadschedule.AcademicScheduleView.UIAction
+import com.stathis.common.base.BaseViewModel
+import com.stathis.domain.students.FetchAcademicScheduleUseCase
+import com.stathis.model.UiModel
+import com.stathis.model.network.NetworkResult
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+internal class AcademicScheduleViewModel @Inject constructor(
+    app: Application,
+    fetchAcademicScheduleUseCase: FetchAcademicScheduleUseCase
+) : BaseViewModel(app) {
+
+    val state: StateFlow<State> = fetchAcademicScheduleUseCase()
+        .map { result -> result.toUiState() }
+        .onStart { emit(State.Loading) }
+        .flowOn(Dispatchers.IO)
+        .stateIn(viewModelScope, SharingStarted.Lazily, State.Loading)
+
+    private val _effect = MutableSharedFlow<Effect>()
+    val effect: SharedFlow<Effect> = _effect.asSharedFlow()
+
+    fun onAction(action: UIAction) {
+        viewModelScope.launch {
+            val effect = when (action) {
+                is UIAction.OnBackArrowTap -> Effect.GoBack
+            }
+
+            _effect.emit(effect)
+        }
+    }
+
+    private fun NetworkResult<List<UiModel>>.toUiState() = when (this) {
+        is NetworkResult.Loading -> State.Loading
+        is NetworkResult.Success<List<UiModel>> -> State.Content(data!!)
+        is NetworkResult.Failure -> State.Error
+    }
+}


### PR DESCRIPTION
### 📝  Description

This PR migrates the academic schedule to jetpack compose.

---

### 🔄  Implementation
- Created new `Fragment` to host new `AcademicScheduleScreen`
- Created `Academic ScheduleView`
- Created `AcademicScheduleViewModel`

---

### 🎬  Demo
N/A

---

### 🧪  Testing
N/A
