### PR TITLE
Target Android 16 (Api level 36)

### DIFF
--- a/buildSrc/src/main/kotlin/Configurations.kt
+++ b/buildSrc/src/main/kotlin/Configurations.kt
@@ -1,8 +1,8 @@
 object Configurations {
 
-    const val COMPILE_SDK_VERSION = 35
+    const val COMPILE_SDK_VERSION = 36
     const val MIN_SDK_VERSION = 27
-    const val TARGET_SDK_VERSION = 35
+    const val TARGET_SDK_VERSION = 36
 
     /**
      * For each release, update these values based on the type of changes:


### PR DESCRIPTION
### 📝  Description

This PR updates the api level from `35` (Android 15) to `36` (Android 16)

---

### 🔄  Implementation
- Updated `compileSdk` & `targetSdk` to `36`

---

### 🎬  Demo
N/A

---

### 🧪  Testing
Run the app and verify that everything is working as expected
