### PR TITLE
[Release] Bump app version to 4.10.0

### DIFF
--- a/buildSrc/src/main/kotlin/Configurations.kt
+++ b/buildSrc/src/main/kotlin/Configurations.kt
@@ -13,7 +13,7 @@ object Configurations {
      */
 
     const val MAJOR_VERSION = 4
-    const val MINOR_VERSION = 9
+    const val MINOR_VERSION = 10
     const val PATCH_VERSION = 0
     const val VERSION_CODE = MAJOR_VERSION * 10000 + MINOR_VERSION * 100 + PATCH_VERSION
     const val VERSION_NAME = "$MAJOR_VERSION.$MINOR_VERSION.$PATCH_VERSION"


### PR DESCRIPTION
### 📝  Description

Release `v.4.10.0`

---

### 🔄  Implementation
- Bumped the version to `4.10.0`

---

### 🎬  Demo
N/A
---

### 🧪  Testing
N/A
